### PR TITLE
新增`谱面链接转换`功能?

### DIFF
--- a/nonebot_plugin_osubot/__init__.py
+++ b/nonebot_plugin_osubot/__init__.py
@@ -13,7 +13,7 @@ from nonebot.params import T_State, ShellCommandArgv, CommandArg
 from nonebot.plugin import PluginMetadata
 from nonebot.rule import ArgumentParser
 from nonebot.log import logger
-from nonebot import on_command, require, on_shell_command, get_driver
+from nonebot import on_command, require, on_shell_command, get_driver, on_regex
 from nonebot_plugin_tortoise_orm import add_model
 from .draw import draw_info, draw_score, draw_map_info, draw_bmap_info, draw_bp, image2bytesio
 from .file import download_map, map_downloaded, download_osu, download_tmp_osu

--- a/nonebot_plugin_osubot/__init__.py
+++ b/nonebot_plugin_osubot/__init__.py
@@ -497,7 +497,7 @@ async def _url(bot: Bot, event: GroupMessageEvent):
     get_msg = str(event.message)
     msg_id = event.message_id
     new_data_num = re.findall("https://osu.ppy.sh/beatmapsets/(.*)#", get_msg)
-    url_1 = "https://kitdu.moe/api/d/"
+    url_1 = "https://kitsu.moe/api/d/"
     url_2 = "https://txy1.sayobot.cn/beatmaps/download/novideo/"
     url_total = f"[CQ:reply,id={msg_id}]kitsu镜像站：{url_1}{new_data_num[0]}\n小夜镜像站：{url_2}{new_data_num[0]}"
     await full.finish(Message(url_total))

--- a/nonebot_plugin_osubot/__init__.py
+++ b/nonebot_plugin_osubot/__init__.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import urllib
+import re
 from pathlib import Path
 from typing import List, Union
 
@@ -488,6 +489,18 @@ async def _help(event: Union[MessageEvent, GuildMessageEvent], msg: Message = Co
     else:
         await osu_help.finish(MessageSegment.reply(event.message_id) + '呜呜，detail都打不对吗(ノ｀Д)ノ')
 
+full = on_regex("https://osu.ppy.sh/beatmapsets/(.*)#")
+
+
+@full.handle()
+async def _url(bot: Bot, event: GroupMessageEvent):
+    get_msg = str(event.message)
+    msg_id = event.message_id
+    new_data_num = re.findall("https://osu.ppy.sh/beatmapsets/(.*)#", get_msg)
+    url_1 = "https://kitdu.moe/api/d/"
+    url_2 = "https://txy1.sayobot.cn/beatmaps/download/novideo/"
+    url_total = f"[CQ:reply,id={msg_id}]kitsu镜像站：{url_1}{new_data_num[0]}\n小夜镜像站：{url_2}{new_data_num[0]}"
+    await full.finish(Message(url_total))
 
 @scheduler.scheduled_job('cron', hour='0')
 async def update_info():


### PR DESCRIPTION
低创，大概就是实现类似sayobot官网那种的，发谱面链接到qq群可以直接返回镜像站的直链链接。
血猫好像境内下载比较慢就没加进去，代码可能需要改动不够规范。
![微信截图20230305004127](https://user-images.githubusercontent.com/52590027/222918693-bc7c5044-4727-4325-b428-2cedd51a3e36.png)

像第一种链接不会转换，只会转换第二种完整样式的链接