### PR TITLE
更新bp榜单的谱面banner功能

### DIFF
--- a/nonebot_plugin_osubot/draw/bp.py
+++ b/nonebot_plugin_osubot/draw/bp.py
@@ -10,8 +10,9 @@ from ..schema import Score
 from ..api import osu_api
 from ..utils import GMN
 from ..mods import get_mods_list
+from ..file import get_projectimg
 
-from .utils import image2bytesio
+from .utils import image2bytesio, draw_fillet
 from .static import *
 
 
@@ -64,7 +65,7 @@ async def draw_pfm(project: str, user: str, score_ls: List[Score], mode: str, lo
         uinfo = f"{user} | {mode.capitalize()} 模式 | BP {low_bound} - {high_bound}"
     else:
         uinfo = f"{user} | {mode.capitalize()} 模式 | 近{day + 1}日新增 BP"
-    draw.text((1450, 50), uinfo, font=Torus_SemiBold_25, anchor='rm')
+    draw.text((1480, 50), uinfo, font=Torus_SemiBold_25, anchor='rm')
     for num, bp in enumerate(score_ls):
         h_num = 82 * num
         # mods
@@ -77,23 +78,40 @@ async def draw_pfm(project: str, user: str, score_ls: List[Score], mode: str, lo
                 bp.rank += 'H'
         # BP排名
         draw.text((15, 144 + h_num), str(num + 1), font=Torus_Regular_20, anchor='lm')
+        # 获取谱面banner
+        bg_url = f'https://assets.ppy.sh/beatmaps/{bp.beatmapset.id}/covers/card.jpg'
+        bg_img = await get_projectimg(bg_url)
+        bg = Image.open(bg_img).convert('RGBA').resize((157, 55))
+        bg_imag = draw_fillet(bg, 5)
+        im.alpha_composite(bg_imag, (45, 114 + h_num))
         # rank
         rank_img = osufile / 'ranking' / f'ranking-{bp.rank}.png'
-        rank_bg = Image.open(rank_img).convert('RGBA').resize((64, 32))
-        im.alpha_composite(rank_bg, (45, 128 + h_num))
+        rank_bg = Image.open(rank_img).convert('RGBA').resize((32, 16))
+        im.alpha_composite(rank_bg, (1366, 122 + h_num))
         # 曲名&作曲
-        draw.text((125, 130 + h_num), f'{bp.beatmapset.title} | by {bp.beatmapset.artist}', font=Torus_Regular_20, anchor='lm')
+        metadata = f'{bp.beatmapset.title} | by {bp.beatmapset.artist}'
+        # 如果曲名&作曲的长度超过75，就截断它
+        if len (metadata) > 75:
+            metadata = metadata [:72] + '...'
+        # 写入曲名&作曲
+        draw.text((215, 125 + h_num), metadata, font=Torus_Regular_20, anchor='lm')
         # 地图版本&时间
         old_time = datetime.strptime(bp.created_at.replace('Z', ''), '%Y-%m-%dT%H:%M:%S')
         new_time = (old_time + timedelta(hours=8)).strftime('%Y-%m-%d %H:%M:%S')
-        draw.text((125, 158 + h_num), f'{bp.beatmap.version} | {new_time}', font=Torus_Regular_20, anchor='lm', fill=(238, 171, 0, 255))
+        # 如果难度名的长度超过50，就截断它
+        difficulty = bp.beatmap.version
+        if len (difficulty) > 50:
+            difficulty = difficulty [:47] + '...'
+        # 写入难度名
+        difficulty = f'{difficulty} | {new_time}'
+        draw.text((215, 158 + h_num), difficulty, font=Torus_Regular_20, anchor='lm', fill=(238, 171, 0, 255))
         # acc
-        draw.text((1250, 130 + h_num), f'{bp.accuracy * 100:.2f}%', font=Torus_SemiBold_20, anchor='lm', fill=(238, 171, 0, 255))
+        draw.text((1280, 130 + h_num), f'{bp.accuracy * 100:.2f}%', font=Torus_SemiBold_20, anchor='lm', fill=(238, 171, 0, 255))
         # mapid
-        draw.text((1250, 158 + h_num), f'ID: {bp.beatmap.id}', font=Torus_Regular_20, anchor='lm')
+        draw.text((1280, 158 + h_num), f'ID: {bp.beatmap.id}', font=Torus_Regular_20, anchor='lm')
         # pp
-        draw.text((1420, 140 + h_num), f'{bp.pp:.0f}', font=Torus_SemiBold_25, anchor='rm', fill=(255, 102, 171, 255))
-        draw.text((1450, 140 + h_num), 'pp', font=Torus_SemiBold_25, anchor='rm', fill=(209, 148, 176, 255))
+        draw.text((1450, 140 + h_num), f'{bp.pp:.0f}', font=Torus_SemiBold_25, anchor='rm', fill=(255, 102, 171, 255))
+        draw.text((1480, 140 + h_num), 'pp', font=Torus_SemiBold_25, anchor='rm', fill=(209, 148, 176, 255))
         # 分割线
         div = Image.new('RGBA', (1450, 2), (46, 53, 56, 255)).convert('RGBA')
         im.alpha_composite(div, (25, 180 + h_num))


### PR DESCRIPTION
又是一段不规范的代码，辛苦好兄弟看看了。

以前：
![OLD](https://github.com/yaowan233/nonebot-plugin-osubot/assets/52590027/34e97caf-6b94-4bee-8144-ae3443beb011)

现在：
![new](https://github.com/yaowan233/nonebot-plugin-osubot/assets/52590027/a3bf97d7-ff90-49b5-8514-37682552d8c6)


顺带加了个标题长度&谱面难度长度的检测，超过特定字符就截断：
![BT](https://github.com/yaowan233/nonebot-plugin-osubot/assets/52590027/bbb3e702-3f43-48e1-95d2-5f313654bf99)
![ND](https://github.com/yaowan233/nonebot-plugin-osubot/assets/52590027/73449da8-6cd7-45e5-af8b-85d37f14b15a)
