### PR TITLE
更人性化的bp指令

### DIFF
--- a/nonebot_plugin_osubot/__init__.py
+++ b/nonebot_plugin_osubot/__init__.py
@@ -233,7 +233,6 @@ async def _score(state: T_State, event: Union[MessageEvent, GuildMessageEvent]):
 
 bp = on_command('bp', priority=11, block=True)
 
-
 @bp.handle(parameterless=[split_msg()])
 async def _bp(state: T_State, event: Union[MessageEvent, GuildMessageEvent]):
     if 'error' in state:
@@ -241,18 +240,19 @@ async def _bp(state: T_State, event: Union[MessageEvent, GuildMessageEvent]):
     user = state['user']
     mode = state['mode']
     mods = state['mods']
-    best = state['para']
-    if not best.isdigit():
+    para = state['para']
+    if '-' in para:
+        await _pfm(state, event)
+        return
+    if not para.isdigit():
         await bp.finish(MessageSegment.reply(event.message_id) + '只能接受纯数字的bp参数')
-    best = int(best)
+    best = int(para)
     if best <= 0 or best > 100:
         await bp.finish(MessageSegment.reply(event.message_id) + '只允许查询bp 1-100 的成绩')
     data = await draw_score('bp', user, NGM[mode], best=best, mods=mods)
     await bp.finish(MessageSegment.reply(event.message_id) + data)
 
-
 pfm = on_command('pfm', priority=11, block=True)
-
 
 @pfm.handle(parameterless=[split_msg()])
 async def _pfm(state: T_State, event: Union[MessageEvent, GuildMessageEvent]):

--- a/nonebot_plugin_osubot/__init__.py
+++ b/nonebot_plugin_osubot/__init__.py
@@ -233,6 +233,7 @@ async def _score(state: T_State, event: Union[MessageEvent, GuildMessageEvent]):
 
 bp = on_command('bp', priority=11, block=True)
 
+
 @bp.handle(parameterless=[split_msg()])
 async def _bp(state: T_State, event: Union[MessageEvent, GuildMessageEvent]):
     if 'error' in state:
@@ -252,7 +253,9 @@ async def _bp(state: T_State, event: Union[MessageEvent, GuildMessageEvent]):
     data = await draw_score('bp', user, NGM[mode], best=best, mods=mods)
     await bp.finish(MessageSegment.reply(event.message_id) + data)
 
+
 pfm = on_command('pfm', priority=11, block=True)
+
 
 @pfm.handle(parameterless=[split_msg()])
 async def _pfm(state: T_State, event: Union[MessageEvent, GuildMessageEvent]):


### PR DESCRIPTION
现在的`bp`和`pfm`指令感觉可以集成为一个，因为感觉有蛮多用户会下意识的发`/bp 1-10`  而不是`/pfm 1-10`
给代码加一个判断，用以支持`/bp 1-10`这样的参数感觉挺好的。
还是看佬怎么想，作用不是很大。

加个判断的话也不会影响原来`pfm`的指令。
edit:添加图片
![131](https://github.com/yaowan233/nonebot-plugin-osubot/assets/52590027/48e43c04-0ea2-4c20-9494-d18c83ff260f)
