### PR TITLE
修复 `bp` 指令解析问题

### DIFF
--- a/nonebot_plugin_osubot/matcher/bp.py
+++ b/nonebot_plugin_osubot/matcher/bp.py
@@ -43,7 +43,7 @@ async def _bp(state: T_State):
     await UniMessage.image(raw=data).send(reply_to=True)
 
 
-@pfm.handle(parameterless=[split_msg(fix_bppara=True)])
+@pfm.handle(parameterless=[split_msg()])
 async def _pfm(state: T_State):
     if "error" in state:
         await UniMessage.text(state["error"]).send(reply_to=True)

--- a/nonebot_plugin_osubot/matcher/bp.py
+++ b/nonebot_plugin_osubot/matcher/bp.py
@@ -11,7 +11,7 @@ pfm = on_command("pfm", priority=11, block=True)
 tbp = on_command("tbp", priority=11, block=True, aliases={'todaybp'})
 
 
-@bp.handle(parameterless=[split_msg()])
+@bp.handle(parameterless=[split_msg(fix_bppara=True)])
 async def _bp(state: T_State):
     if "error" in state:
         await UniMessage.text(state["error"]).send(reply_to=True)
@@ -43,7 +43,7 @@ async def _bp(state: T_State):
     await UniMessage.image(raw=data).send(reply_to=True)
 
 
-@pfm.handle(parameterless=[split_msg()])
+@pfm.handle(parameterless=[split_msg(fix_bppara=True)])
 async def _pfm(state: T_State):
     if "error" in state:
         await UniMessage.text(state["error"]).send(reply_to=True)

--- a/nonebot_plugin_osubot/matcher/utils.py
+++ b/nonebot_plugin_osubot/matcher/utils.py
@@ -7,7 +7,7 @@ from ..utils import mods2list
 from ..database.models import UserData
 
 
-def split_msg():
+def split_msg(fix_bppara=False):
     async def dependency(
         event: Event,
         state: T_State,
@@ -82,6 +82,11 @@ def split_msg():
         if state["user"] == 0 and not state["user"]:
             state["error"] = "该账号尚未绑定，请输入 /bind 用户名 绑定账号"
         state["day"] = int(state["day"])
+        if fix_bppara:
+            if state["para"] and "-" not in state["para"] and (not state["para"].isdigit() or not (1 <= int(state["para"]) <= 100)):
+                state["user"] = state["para"]
+                state["is_name"] = True
+                state["para"] = ""
 
     return Depends(dependency)
 

--- a/nonebot_plugin_osubot/matcher/utils.py
+++ b/nonebot_plugin_osubot/matcher/utils.py
@@ -83,10 +83,17 @@ def split_msg(fix_bppara=False):
             state["error"] = "该账号尚未绑定，请输入 /bind 用户名 绑定账号"
         state["day"] = int(state["day"])
         if fix_bppara:
-            if state["para"] and "-" not in state["para"] and (not state["para"].isdigit() or not (1 <= int(state["para"]) <= 100)):
-                state["user"] = state["para"]
-                state["is_name"] = True
-                state["para"] = ""
+            if state["para"]:
+                if "-" in state["para"]:
+                    parts = state["para"].split("-")
+                    if not (parts[0].isdigit() and parts[1].isdigit()):
+                        state["user"] = state["para"]
+                        state["is_name"] = True
+                        state["para"] = ""
+                elif not state["para"].isdigit() or not (1 <= int(state["para"]) <= 100):
+                    state["user"] = state["para"]
+                    state["is_name"] = True
+                    state["para"] = ""
 
     return Depends(dependency)
 


### PR DESCRIPTION
应该没啥问题，旧版本测试ok了，没在新版测试过。
就直接`bp xxx` 查别人也可以不用带数字了。
![QQ截图20240308234946](https://github.com/yaowan233/nonebot-plugin-osubot/assets/52590027/b9b1ae87-5800-417c-ab11-bbc93cfe2144)