### PR TITLE
修改函数等待逻辑

### DIFF
--- a/nonebot_plugin_osubot/network/first_response.py
+++ b/nonebot_plugin_osubot/network/first_response.py
@@ -24,7 +24,7 @@ async def get_first_response(urls: List[str]):
     async with AsyncClient(proxies=proxy, follow_redirects=True) as client:
         tasks = [fetch_url(client, url) for url in urls]
         try:
-            for future in asyncio.as_completed(tasks, timeout=20):
+            for future in asyncio.as_completed(tasks, timeout=10):
                 response = await future
                 if response is not None:
                     return response


### PR DESCRIPTION
现在的`get_first_response` 逻辑是其中3个api，如果有一个完成了，那么就不会请求其他两个api。
这导致假设`subapi`和`sayobot`都无法请求BG，而`osu.direct`可以的时候，然后`osu.direct`响应比较慢，就会返回无法下载BG。

所以修改成等待所有任务完成，如果都无资源才返回 无法下载BG。