### PR TITLE
修复 `score` 没有指定mods时不返回最高分数

### DIFF
--- a/nonebot_plugin_osubot/draw/score.py
+++ b/nonebot_plugin_osubot/draw/score.py
@@ -147,6 +147,7 @@ async def get_score_data(
             else:
                 return f'未找到开启 {"|".join(mods)} Mods的成绩'
     else:
+        score_ls.sort(key=lambda x: x.legacy_total_score, reverse=True)
         score_info = score_ls[0]
     sayo_map_info = await task3
     path = map_path / str(sayo_map_info.data.sid)


### PR DESCRIPTION
如下图第一个例子，现在只会在指定了mods才会返回最高分数。
应该即使没有指定mods，也返回最高分数。

![DF7C44F0CFFD0166DAC22B4B48FA525E](https://github.com/yaowan233/nonebot-plugin-osubot/assets/52590027/77fd1d5d-9433-4cb1-b9c2-2af67b95a735)
