### PR TITLE
优化 `pfm` 获取banner使用缓存

### DIFF
--- a/nonebot_plugin_osubot/draw/bp.py
+++ b/nonebot_plugin_osubot/draw/bp.py
@@ -1,4 +1,3 @@
-import os
 import asyncio
 from io import BytesIO
 from time import mktime, strptime
@@ -93,14 +92,15 @@ async def draw_pfm(
     task0 = [
         get_pfm_img(
             f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/list.jpg",
-            os.path.join(map_path, f"{i.beatmapset.id}/covers/{i.beatmap.id}/list.jpg"),
+            (map_path / f"{i.beatmapset.id}/list.jpg").as_posix(),
         )
         for i in score_ls_filtered
     ]
+
     task1 = [
         get_pfm_img(
             f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/cover.jpg",
-            os.path.join(map_path, f"{i.beatmapset.id}/covers/{i.beatmap.id}/cover.jpg"),
+            (map_path /f"{i.beatmapset.id}/cover.jpg").as_posix(),
         )
         for i in score_ls_filtered
     ]
@@ -139,19 +139,31 @@ async def draw_pfm(
 
         # 获取谱面大banner
         try:
-            banner = Image.open(large_banner_ls[num]).convert("RGBA").resize((650, 150))
+            banner_data = large_banner_ls[num]
+            if banner_data:
+                banner = Image.open(banner_data).convert("RGBA").resize((650, 150))
+            else:
+                banner = Image.new("RGBA", (650, 150), (0, 0, 0, 255))
             banner_with_fillet = draw_fillet2(banner, 15)
             im.alpha_composite(banner_with_fillet, (45 + offset, 114 + h_num))
         except UnidentifiedImageError:
-            ...
+            black_banner = Image.new("RGBA", (650, 150), (0, 0, 0, 255))
+            banner_with_fillet = draw_fillet2(black_banner, 15)
+            im.alpha_composite(banner_with_fillet, (45 + offset, 114 + h_num))
 
         # 获取谱面banner
         try:
-            bg = Image.open(bg_ls[num]).convert("RGBA").resize((150, 150))
+            bg_data = bg_ls[num]
+            if bg_data:
+                bg = Image.open(bg_data).convert("RGBA").resize((150, 150))
+            else:
+                bg = Image.new("RGBA", (150, 150), (0, 0, 0, 0))
             bg_imag = draw_fillet(bg, 15)
             im.alpha_composite(bg_imag, (45 + offset, 114 + h_num))
         except UnidentifiedImageError:
-            ...
+            black_bg = Image.new("RGBA", (150, 150), (0, 0, 0, 0))
+            bg_imag = draw_fillet(black_bg, 15)
+            im.alpha_composite(bg_imag, (45 + offset, 114 + h_num))
 
         # mods
         if bp.mods:

--- a/nonebot_plugin_osubot/draw/bp.py
+++ b/nonebot_plugin_osubot/draw/bp.py
@@ -100,7 +100,7 @@ async def draw_pfm(
     task1 = [
         get_pfm_img(
             f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/cover.jpg",
-            (map_path /f"{i.beatmapset.id}/cover.jpg").as_posix(),
+            (map_path / f"{i.beatmapset.id}/cover.jpg").as_posix(),
         )
         for i in score_ls_filtered
     ]

--- a/nonebot_plugin_osubot/draw/bp.py
+++ b/nonebot_plugin_osubot/draw/bp.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 from io import BytesIO
 from time import mktime, strptime
@@ -12,7 +13,7 @@ from ..schema import NewScore
 from ..schema.score import Mod
 from ..database import UserData
 from ..mods import get_mods_list
-from ..file import get_projectimg
+from ..file import get_pfm_img, map_path
 from .utils import draw_fillet, draw_fillet2
 from .score import cal_legacy_acc, cal_legacy_rank
 from .static import BgImg, Image, BgImg1, Torus_Regular_20, Torus_Regular_25, Torus_SemiBold_25, osufile
@@ -90,10 +91,16 @@ async def draw_pfm(
     day: int = 0,
 ) -> Union[str, BytesIO]:
     task0 = [
-        get_projectimg(f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/list.jpg") for i in score_ls_filtered
+        get_pfm_img(
+            f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/list.jpg",
+            os.path.join(map_path, f"{i.beatmapset.id}/covers/{i.beatmap.id}/list.jpg")
+        ) for i in score_ls_filtered
     ]
     task1 = [
-        get_projectimg(f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/cover.jpg") for i in score_ls_filtered
+        get_pfm_img(
+            f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/cover.jpg",
+            os.path.join(map_path, f"{i.beatmapset.id}/covers/{i.beatmap.id}/cover.jpg")
+        ) for i in score_ls_filtered
     ]
     bg_ls = await asyncio.gather(*task0)
     large_banner_ls = await asyncio.gather(*task1)

--- a/nonebot_plugin_osubot/draw/bp.py
+++ b/nonebot_plugin_osubot/draw/bp.py
@@ -139,31 +139,19 @@ async def draw_pfm(
 
         # 获取谱面大banner
         try:
-            banner_data = large_banner_ls[num]
-            if banner_data:
-                banner = Image.open(banner_data).convert("RGBA").resize((650, 150))
-            else:
-                banner = Image.new("RGBA", (650, 150), (0, 0, 0, 255))
+            banner = Image.open(large_banner_ls[num]).convert("RGBA").resize((650, 150))
             banner_with_fillet = draw_fillet2(banner, 15)
             im.alpha_composite(banner_with_fillet, (45 + offset, 114 + h_num))
         except UnidentifiedImageError:
-            black_banner = Image.new("RGBA", (650, 150), (0, 0, 0, 255))
-            banner_with_fillet = draw_fillet2(black_banner, 15)
-            im.alpha_composite(banner_with_fillet, (45 + offset, 114 + h_num))
+            ...
 
         # 获取谱面banner
         try:
-            bg_data = bg_ls[num]
-            if bg_data:
-                bg = Image.open(bg_data).convert("RGBA").resize((150, 150))
-            else:
-                bg = Image.new("RGBA", (150, 150), (0, 0, 0, 0))
+            bg = Image.open(bg_ls[num]).convert("RGBA").resize((150, 150))
             bg_imag = draw_fillet(bg, 15)
             im.alpha_composite(bg_imag, (45 + offset, 114 + h_num))
         except UnidentifiedImageError:
-            black_bg = Image.new("RGBA", (150, 150), (0, 0, 0, 0))
-            bg_imag = draw_fillet(black_bg, 15)
-            im.alpha_composite(bg_imag, (45 + offset, 114 + h_num))
+            ...
 
         # mods
         if bp.mods:

--- a/nonebot_plugin_osubot/draw/bp.py
+++ b/nonebot_plugin_osubot/draw/bp.py
@@ -92,7 +92,7 @@ async def draw_pfm(
     task0 = [
         get_pfm_img(
             f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/list.jpg",
-            (map_path / f"{i.beatmapset.id}/list.jpg").as_posix(),
+            map_path / f"{i.beatmapset.id}" / "list.jpg",
         )
         for i in score_ls_filtered
     ]
@@ -100,7 +100,7 @@ async def draw_pfm(
     task1 = [
         get_pfm_img(
             f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/cover.jpg",
-            (map_path / f"{i.beatmapset.id}/cover.jpg").as_posix(),
+            map_path / f"{i.beatmapset.id}" / "cover.jpg",
         )
         for i in score_ls_filtered
     ]

--- a/nonebot_plugin_osubot/draw/bp.py
+++ b/nonebot_plugin_osubot/draw/bp.py
@@ -13,7 +13,7 @@ from ..schema import NewScore
 from ..schema.score import Mod
 from ..database import UserData
 from ..mods import get_mods_list
-from ..file import get_pfm_img, map_path
+from ..file import map_path, get_pfm_img
 from .utils import draw_fillet, draw_fillet2
 from .score import cal_legacy_acc, cal_legacy_rank
 from .static import BgImg, Image, BgImg1, Torus_Regular_20, Torus_Regular_25, Torus_SemiBold_25, osufile
@@ -93,14 +93,16 @@ async def draw_pfm(
     task0 = [
         get_pfm_img(
             f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/list.jpg",
-            os.path.join(map_path, f"{i.beatmapset.id}/covers/{i.beatmap.id}/list.jpg")
-        ) for i in score_ls_filtered
+            os.path.join(map_path, f"{i.beatmapset.id}/covers/{i.beatmap.id}/list.jpg"),
+        )
+        for i in score_ls_filtered
     ]
     task1 = [
         get_pfm_img(
             f"https://assets.ppy.sh/beatmaps/{i.beatmapset.id}/covers/cover.jpg",
-            os.path.join(map_path, f"{i.beatmapset.id}/covers/{i.beatmap.id}/cover.jpg")
-        ) for i in score_ls_filtered
+            os.path.join(map_path, f"{i.beatmapset.id}/covers/{i.beatmap.id}/cover.jpg"),
+        )
+        for i in score_ls_filtered
     ]
     bg_ls = await asyncio.gather(*task0)
     large_banner_ls = await asyncio.gather(*task1)

--- a/nonebot_plugin_osubot/file.py
+++ b/nonebot_plugin_osubot/file.py
@@ -1,4 +1,3 @@
-import os
 import re
 import random
 from pathlib import Path

--- a/nonebot_plugin_osubot/file.py
+++ b/nonebot_plugin_osubot/file.py
@@ -81,8 +81,7 @@ async def get_projectimg(url: str) -> BytesIO:
     return im
 
 
-async def get_pfm_img(url: str, cache_path: Union[str, Path]) -> BytesIO:
-    cache_path = Path(cache_path)
+async def get_pfm_img(url: str, cache_path: Path) -> BytesIO:
     cache_dir = cache_path.parent
     if not cache_dir.exists():
         cache_dir.mkdir(parents=True, exist_ok=True)

--- a/nonebot_plugin_osubot/file.py
+++ b/nonebot_plugin_osubot/file.py
@@ -89,10 +89,10 @@ async def get_pfm_img(url: str, cache_path: Union[str, Path]) -> BytesIO:
     if cache_path.exists():
         with cache_path.open("rb") as f:
             return BytesIO(f.read())
-    response = await safe_async_get(url)
-    if response.status_code >= 400:
+    req = await safe_async_get(url)
+    if not req or req.status_code >= 400:
         return BytesIO()
-    image_data = response.content
+    image_data = req.content
     with cache_path.open("wb") as f:
         f.write(image_data)
     return BytesIO(image_data)

--- a/nonebot_plugin_osubot/file.py
+++ b/nonebot_plugin_osubot/file.py
@@ -1,3 +1,4 @@
+import os
 import re
 import random
 from pathlib import Path
@@ -79,6 +80,23 @@ async def get_projectimg(url: str) -> BytesIO:
     data = req.read()
     im = BytesIO(data)
     return im
+
+
+async def get_pfm_img(url: str, cache_path: str) -> BytesIO:
+    cache_dir = os.path.dirname(cache_path)
+    if not os.path.exists(cache_dir):
+        os.makedirs(cache_dir)
+    if os.path.exists(cache_path):
+        with open(cache_path, "rb") as f:
+            return BytesIO(f.read())
+    req = await safe_async_get(url)
+    if req.status_code == 200:
+        image_data = req.read()
+        with open(cache_path, "wb") as f:
+            f.write(image_data)
+        return BytesIO(image_data)
+    else:
+        raise Exception("图片下载失败")
 
 
 def re_map(file: Union[bytes, Path]) -> str:


### PR DESCRIPTION
新增函数 `get_pfm_img`
目录结构：
`data\osu\map\{setid}\cover.jpg`
`data\osu\map\{setid}\list.jpg`
快多了↓ bp1-100 13s
![QQ截图20240802111352](https://github.com/user-attachments/assets/2ccfc84c-5f0c-4b68-bc81-8f0ef6729228)
