### PR TITLE
🐛 修复极端情况下 ctb预览 图片空白的问题

### DIFF
--- a/nonebot_plugin_osubot/draw/catch_preview_templates/pic.html
+++ b/nonebot_plugin_osubot/draw/catch_preview_templates/pic.html
@@ -41,7 +41,7 @@
 
         const createImg = function () {
             const self = this;
-            const osufile = `{{ osu_file }}`;
+            const osufile = {{ osu_file|tojson }};
             let SPEED = 1;
             let mods = {
                 HR: {{ is_hr }},


### PR DESCRIPTION
使用 `tojson`
![miyuki](https://github.com/user-attachments/assets/c243101e-f33c-43af-9c53-fc934ec74123)
![HiOSU Bot](https://github.com/user-attachments/assets/5ae8c60a-c3fb-43c6-80f8-1c6c273f3251)
