### PR TITLE
feat(match): /mp 多图分页战报，支持压缩与 lazer 房间

### DIFF
--- a/src/nonebot_plugin_osubot/draw/image_utils.py
+++ b/src/nonebot_plugin_osubot/draw/image_utils.py
@@ -1,0 +1,28 @@
+from io import BytesIO
+
+from PIL import Image
+
+
+def compress_jpeg(
+    image_bytes: bytes,
+    *,
+    max_width: int = 1200,
+    quality: int = 85,
+    background_color: tuple[int, int, int] = (13, 13, 20),
+) -> bytes:
+    """Compress an image as JPEG, returning the original bytes on decoding failure."""
+    try:
+        image = Image.open(BytesIO(image_bytes))
+        if image.width > max_width:
+            ratio = max_width / image.width
+            image = image.resize((max_width, int(image.height * ratio)), Image.LANCZOS)
+        if image.mode != "RGB":
+            background = Image.new("RGB", image.size, background_color)
+            image = image.convert("RGBA")
+            background.paste(image, mask=image.getchannel("A"))
+            image = background
+        output = BytesIO()
+        image.save(output, format="JPEG", quality=quality, optimize=True)
+        return output.getvalue()
+    except Exception:
+        return image_bytes

--- a/src/nonebot_plugin_osubot/draw/match_history.py
+++ b/src/nonebot_plugin_osubot/draw/match_history.py
@@ -346,10 +346,7 @@ async def _convert_rooms_to_match_format(raw: dict, match_id: str) -> dict:
             logger.debug(f"[rooms] playlist_item {playlist_item_id}: 被强制关闭(abort)，跳过")
             continue
 
-        scores_url = (
-            f"https://osu.ppy.sh/api/v2/rooms/{match_id}"
-            f"/playlist/{playlist_item_id}/scores"
-        )
+        scores_url = f"https://osu.ppy.sh/api/v2/rooms/{match_id}/playlist/{playlist_item_id}/scores"
 
         try:
             scores_data = await api_info("matches", scores_url)
@@ -386,17 +383,19 @@ async def _convert_rooms_to_match_format(raw: dict, match_id: str) -> dict:
             if team_colour not in ("red", "blue"):
                 team_colour = "none"
 
-            game_scores.append({
-                "user_id": s.get("user_id"),
-                "score": s.get("total_score", 0),
-                "accuracy": s.get("accuracy", 0),
-                "max_combo": s.get("max_combo", 0),
-                "mods": _parse_mods(s.get("mods", [])),
-                "match": {
-                    "team": team_colour,
-                    "passed": bool(s.get("passed", True)),  # ← 透传是否通过
-                },
-            })
+            game_scores.append(
+                {
+                    "user_id": s.get("user_id"),
+                    "score": s.get("total_score", 0),
+                    "accuracy": s.get("accuracy", 0),
+                    "max_combo": s.get("max_combo", 0),
+                    "mods": _parse_mods(s.get("mods", [])),
+                    "match": {
+                        "team": team_colour,
+                        "passed": bool(s.get("passed", True)),  # ← 透传是否通过
+                    },
+                }
+            )
 
         if not game_scores:
             continue
@@ -448,12 +447,14 @@ async def _convert_rooms_to_match_format(raw: dict, match_id: str) -> dict:
             "scores": game_scores,
         }
 
-        events.append({
-            "id": playlist_item_id,
-            "detail": {"type": "other"},
-            "timestamp": item.get("played_at", ""),
-            "game": game,
-        })
+        events.append(
+            {
+                "id": playlist_item_id,
+                "detail": {"type": "other"},
+                "timestamp": item.get("played_at", ""),
+                "game": game,
+            }
+        )
 
     return {
         "match": match_meta,
@@ -477,9 +478,7 @@ def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str |
     all_games = [
         event.game
         for event in match_info.events
-        if event.detail.type == "other"
-        and event.game is not None
-        and event.game.scores
+        if event.detail.type == "other" and event.game is not None and event.game.scores
     ]
     if not all_games:
         raise ValueError("该多人房没有可展示的对局")
@@ -494,11 +493,7 @@ def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str |
     team_type = team_type_filter or mode([game.team_type for game in games])
     is_team = team_type in ("team-vs", "tag-team-vs")
     if is_team:
-        _has_team = any(
-            (score.match or {}).get("team") in ("red", "blue")
-            for game in games
-            for score in game.scores
-        )
+        _has_team = any((score.match or {}).get("team") in ("red", "blue") for game in games for score in game.scores)
         if not _has_team:
             team_type = "head-to-head"
             is_team = False
@@ -523,36 +518,30 @@ def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str |
             # ── 队伍标签拼接逻辑 ──
             if user:
                 team = getattr(user, "team", None)
-                tag = (
-                    getattr(team, "short_name", None) or getattr(team, "name", None)
-                ) if team else None
+                tag = (getattr(team, "short_name", None) or getattr(team, "name", None)) if team else None
                 display_name = f"[{tag}] {user.username}" if tag else user.username
             else:
                 display_name = str(score.user_id)
             # ── 队伍标签拼接逻辑结束 ──
-            player_rows.append({
-                "user_id": score.user_id,
-                "name": display_name,
-                "avatar": user.avatar_url if user else f"https://a.ppy.sh/{score.user_id}",
-                "team": (score.match or {}).get("team", "none"),
-                "passed": (score.match or {}).get("passed", True),
-                "score": score.score or 0,
-                "accuracy": (score.accuracy or 0) * 100,
-                "combo": score.max_combo or 0,
-                "mods": _score_mods(game.mods, score.mods),
-            })
+            player_rows.append(
+                {
+                    "user_id": score.user_id,
+                    "name": display_name,
+                    "avatar": user.avatar_url if user else f"https://a.ppy.sh/{score.user_id}",
+                    "team": (score.match or {}).get("team", "none"),
+                    "passed": (score.match or {}).get("passed", True),
+                    "score": score.score or 0,
+                    "accuracy": (score.accuracy or 0) * 100,
+                    "combo": score.max_combo or 0,
+                    "mods": _score_mods(game.mods, score.mods),
+                }
+            )
 
         # ── 队伍总分：与 osu! 官方判定一致，只统计通过(passed)玩家的分数 ──
         # 参考 osu-web resources/js/legacy-match/content.tsx：
         #   if (!score.passed) continue; scores[team] += score.total_score;
-        red_score = sum(
-            p["score"] for p in player_rows
-            if p["team"] == "red" and p["passed"]
-        )
-        blue_score = sum(
-            p["score"] for p in player_rows
-            if p["team"] == "blue" and p["passed"]
-        )
+        red_score = sum(p["score"] for p in player_rows if p["team"] == "red" and p["passed"])
+        blue_score = sum(p["score"] for p in player_rows if p["team"] == "blue" and p["passed"])
         winner = "none"
         if red_score > blue_score:
             winner = "red"
@@ -561,29 +550,27 @@ def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str |
             winner = "blue"
             blue_wins += 1
 
-        rendered_games.append({
-            "index": index,
-            "map_id": game.beatmap_id,
-            "title": beatmapset.title if beatmapset else f"Beatmap {game.beatmap_id}",
-            "version": beatmap.version if beatmap else "Unknown Difficulty",
-            "creator": beatmapset.creator if beatmapset else "unknown",
-            "cover": (
-                beatmapset.covers.cover
-                if beatmapset
-                else (
-                    f"https://assets.ppy.sh/beatmaps/{beatmap.beatmapset_id}/covers/cover.jpg"
-                    if beatmap
-                    else ""
-                )
-            ),
-            "stars": beatmap.difficulty_rating if beatmap else 0,
-            "winner": winner,
-            "red_score": red_score,
-            "blue_score": blue_score,
-            "players": player_rows,
-            "red_players": [p for p in player_rows if p["team"] == "red"],
-            "blue_players": [p for p in player_rows if p["team"] == "blue"],
-        })
+        rendered_games.append(
+            {
+                "index": index,
+                "map_id": game.beatmap_id,
+                "title": beatmapset.title if beatmapset else f"Beatmap {game.beatmap_id}",
+                "version": beatmap.version if beatmap else "Unknown Difficulty",
+                "creator": beatmapset.creator if beatmapset else "unknown",
+                "cover": (
+                    beatmapset.covers.cover
+                    if beatmapset
+                    else (f"https://assets.ppy.sh/beatmaps/{beatmap.beatmapset_id}/covers/cover.jpg" if beatmap else "")
+                ),
+                "stars": beatmap.difficulty_rating if beatmap else 0,
+                "winner": winner,
+                "red_score": red_score,
+                "blue_score": blue_score,
+                "players": player_rows,
+                "red_players": [p for p in player_rows if p["team"] == "red"],
+                "blue_players": [p for p in player_rows if p["team"] == "blue"],
+            }
+        )
 
     if not rendered_games:
         raise ValueError("该多人房没有有效成绩")
@@ -598,11 +585,7 @@ def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str |
         "red_wins": red_wins,
         "blue_wins": blue_wins,
         "game_count": len(rendered_games),
-        "player_count": len({
-            player["user_id"]
-            for game in rendered_games
-            for player in game["players"]
-        }),
+        "player_count": len({player["user_id"] for game in rendered_games for player in game["players"]}),
         "team_size": max(
             (max(len(g["red_players"]), len(g["blue_players"])) for g in rendered_games),
             default=0,
@@ -624,9 +607,7 @@ async def draw_match_card(data: dict) -> bytes:
         (TEMPLATE_PATH / "index.html").as_uri(),
         {"width": 1280, "height": 900},
     ) as page:
-        await page.set_content(
-            await template.render_async(**data), wait_until="domcontentloaded"
-        )
+        await page.set_content(await template.render_async(**data), wait_until="domcontentloaded")
         await page.evaluate(
             "Promise.race([Promise.all([document.fonts.ready,"
             "...Array.from(document.images,x=>x.decode().catch(()=>{}))]),"
@@ -661,27 +642,22 @@ async def draw_match_history(match_id: str, query_type: str = "auto") -> list[by
     # ── Step 1: 尝试获取原始数据 ──
     if query_type in ("match", "auto"):
         try:
-            raw = await api_info(
-                "matches", f"https://osu.ppy.sh/api/v2/matches/{match_id}"
-            )
+            raw = await api_info("matches", f"https://osu.ppy.sh/api/v2/matches/{match_id}")
             source = "matches"
         except Exception:
             raw = None
 
     if raw is None and query_type in ("room", "auto"):
         try:
-            raw = await api_info(
-                "matches", f"https://osu.ppy.sh/api/v2/rooms/{match_id}"
-            )
+            raw = await api_info("matches", f"https://osu.ppy.sh/api/v2/rooms/{match_id}")
             source = "rooms"
         except Exception:
             raw = None
 
     if raw is None:
         from ..exceptions import NetworkError as OsubotNetworkError
-        raise OsubotNetworkError(
-            f"未找到 ID 为 {match_id} 的比赛/多人房，请检查 ID 是否正确。"
-        )
+
+        raise OsubotNetworkError(f"未找到 ID 为 {match_id} 的比赛/多人房，请检查 ID 是否正确。")
 
     # ── Step 2: 如果是 rooms 格式，转换为 matches 格式 ──
     if source == "rooms" or _is_rooms_response(raw):
@@ -694,9 +670,7 @@ async def draw_match_history(match_id: str, query_type: str = "auto") -> list[by
     all_games = [
         event.game
         for event in match_info.events
-        if event.detail.type == "other"
-        and event.game is not None
-        and event.game.scores
+        if event.detail.type == "other" and event.game is not None and event.game.scores
     ]
     if not all_games:
         raise ValueError("该多人房没有可展示的对局")

--- a/src/nonebot_plugin_osubot/draw/match_history.py
+++ b/src/nonebot_plugin_osubot/draw/match_history.py
@@ -1,4 +1,3 @@
-import io
 import re
 from pathlib import Path
 from datetime import datetime
@@ -6,35 +5,18 @@ from statistics import mode
 
 import jinja2
 
-try:  # Pillow 可选依赖：用于压缩图片；未安装时自动回退为原图
-    from PIL import Image
-
-    _HAS_PIL = True
-except ImportError:  # pragma: no cover
-    _HAS_PIL = False
-
 from ..api import api_info
+from ..match_room import convert_room_to_match, is_room_response
 from ..schema.match import Match
 from .browser import persistent_page
-from nonebot.log import logger
+from .image_utils import compress_jpeg
 
 
 TEMPLATE_PATH = Path(__file__).parent / "match_templates"
 MOD_PATH = Path(__file__).parent.parent / "osufile" / "mods"
 
-# ============ 分页 / 压缩配置（可按需调整） ============
+# ============ 分页配置（可按需调整） ============
 MAX_ROWS_PER_PAGE = 32
-MAX_IMAGE_WIDTH = 1200
-JPEG_QUALITY = 85
-BG_COLOR = (13, 13, 20)
-
-# ============ Rooms API type → Match schema team_type 映射 ============
-_ROOM_TYPE_MAP: dict[str, str] = {
-    "team_versus": "team-vs",
-    "head_to_head": "head-to-head",
-    "tag_coop": "tag-coop",
-    "tag_team_vs": "tag-team-vs",
-}
 
 
 def _score_mods(game_mods: list[str], player_mods: list[str]) -> list[str]:
@@ -84,389 +66,16 @@ def _chunk_games(games: list[dict], max_rows: int = MAX_ROWS_PER_PAGE) -> list[l
     return chunks
 
 
-def _compress_image(img_bytes: bytes) -> bytes:
-    """使用 Pillow 压缩截图；未安装或失败时返回原图"""
-    if not _HAS_PIL:
-        return img_bytes
-    try:
-        im = Image.open(io.BytesIO(img_bytes))
-        if im.width > MAX_IMAGE_WIDTH:
-            ratio = MAX_IMAGE_WIDTH / im.width
-            im = im.resize((MAX_IMAGE_WIDTH, int(im.height * ratio)), Image.LANCZOS)
-        if im.mode != "RGB":
-            background = Image.new("RGB", im.size, BG_COLOR)
-            im = im.convert("RGBA")
-            background.paste(im, mask=im.split()[-1])
-            im = background
-        buf = io.BytesIO()
-        im.save(buf, format="JPEG", quality=JPEG_QUALITY, optimize=True)
-        return buf.getvalue()
-    except Exception:
-        return img_bytes
-
-
-def _merge_images_vertically(pages: list[bytes]) -> bytes:
-    """将多页图片纵向拼接为一张长图"""
-    if not _HAS_PIL or len(pages) <= 1:
-        return pages[0] if pages else b""
-    try:
-        images = [Image.open(io.BytesIO(p)) for p in pages]
-        total_width = max(im.width for im in images)
-        total_height = sum(im.height for im in images)
-        merged = Image.new("RGB", (total_width, total_height), BG_COLOR)
-        y_offset = 0
-        for im in images:
-            if im.mode != "RGB":
-                bg = Image.new("RGB", im.size, BG_COLOR)
-                bg.paste(im, mask=im.split()[-1])
-                im = bg
-            merged.paste(im, (0, y_offset))
-            y_offset += im.height
-        buf = io.BytesIO()
-        merged.save(buf, format="JPEG", quality=JPEG_QUALITY, optimize=True)
-        return buf.getvalue()
-    except Exception:
-        return pages[0]
-
-
-# ==================== Rooms API 适配层 ====================
-
-
-def _is_rooms_response(raw: dict) -> bool:
-    """
-    判断 API 返回的是 /rooms/ 格式还是 /matches/ 格式。
-
-    /matches/ 响应一定有顶层 "match" 键；
-    /rooms/ 响应有 "playlist" 或 "category" 键，且没有 "match"。
-    """
-    return "match" not in raw and ("playlist" in raw or "category" in raw)
-
-
-def _parse_mods(raw_mods: list) -> list[str]:
-    """
-    将 osu! API v2 返回的 mods 列表统一为 acronym 字符串列表。
-
-    API 可能返回两种格式：
-      - 字符串列表: ["HD", "DT"]
-      - 对象列表:   [{"acronym": "HD", ...}, {"acronym": "DT", ...}]
-    """
-    result: list[str] = []
-    for m in raw_mods:
-        if isinstance(m, dict):
-            acronym = m.get("acronym", "")
-            if acronym:
-                result.append(acronym)
-        elif isinstance(m, str) and m:
-            result.append(m)
-    return result
-
-
-async def _fetch_room_team_map(
-    match_id: str,
-) -> tuple[dict[int, dict[str, str]], dict[str, str] | None, set[int], dict[int, str]]:
-    """
-    从 /api/v2/rooms/{id}/events 接口解析：
-      1. 每个 playlist item 的红蓝分队映射
-      2. 被强制关闭(abort)的 playlist_item_id 集合
-      3. 每个 playlist item 自己的真实模式（details.room_type）
-
-    osu! 官方页面渲染 --red/--blue 的数据来源就是 events 接口里
-    每个 playlist_item.details.teams，结构为：
-        { "user_id字符串": "red" | "blue" }
-
-    注意：同一房间可能在运行中切换模式（如先 head_to_head 热身、后 team_versus
-    正赛），因此**每个 playlist item 单独记录自己的 room_type**，顶层 /rooms/{id}
-    的 type 字段只作为兜底。
-
-    而被强制关闭的对局在 events 流里有 event_type == "game_aborted"
-    （正常完成的是 "game_completed"），据此可精确剔除 abort 局。
-
-    Returns
-    -------
-    pid_teams : dict[int, dict[str, str]]
-        按 playlist_item_id 索引的精确队伍映射：{ pid: { uid_str: "red"/"blue" } }
-    fallback_teams : dict[str, str] | None
-        全局兜底映射（合并所有 item 的 teams），用于无法精确匹配 pid 的场景。
-        解析失败时返回 None。
-    aborted_pids : set[int]
-        被强制关闭(game_aborted)的 playlist_item_id 集合。
-    pid_room_types : dict[int, str]
-        按 playlist_item_id 索引的房间模式（原始值如 "team_versus"/"head_to_head"），
-        该 item 解析不到时不存在于字典中。
-    """
-    events_url = f"https://osu.ppy.sh/api/v2/rooms/{match_id}/events"
-
-    pid_teams: dict[int, dict[str, str]] = {}
-    fallback_teams: dict[str, str] = {}
-    aborted_pids: set[int] = set()
-    pid_room_types: dict[int, str] = {}
-
-    try:
-        events_data = await api_info("matches", events_url)
-    except Exception as exc:
-        logger.debug(f"[team-map] room {match_id}: 请求 events 失败，降级 head-to-head ({exc})")
-        return {}, None, set(), {}
-
-    # ── 从 events 流提取 game_aborted 的 playlist_item_id ──
-    raw_events: list = []
-    if isinstance(events_data, dict):
-        raw_events = events_data.get("events", []) or []
-    for ev in raw_events:
-        if not isinstance(ev, dict):
-            continue
-        if ev.get("event_type") == "game_aborted":
-            pid = ev.get("playlist_item_id")
-            if pid is not None:
-                try:
-                    aborted_pids.add(int(pid))
-                except (TypeError, ValueError):
-                    pass
-
-    # events 接口的 playlist items 可能在 "playlist" 或 "events" 里，做兼容
-    playlist_items: list[dict] = []
-    if isinstance(events_data, dict):
-        playlist_items = events_data.get("playlist") or events_data.get("playlist_items") or []
-        # 部分版本 events 是事件流，playlist item 嵌在 event.playlist_item 里
-        if not playlist_items:
-            for ev in raw_events:
-                pi = ev.get("playlist_item") if isinstance(ev, dict) else None
-                if isinstance(pi, dict):
-                    playlist_items.append(pi)
-
-    for item in playlist_items:
-        if not isinstance(item, dict):
-            continue
-        pid = item.get("id")
-        details = item.get("details") or {}
-
-        # ── 记录该 item 自己的房间模式 ──
-        rt_raw = details.get("room_type")
-        if rt_raw and pid is not None:
-            try:
-                pid_room_types[int(pid)] = str(rt_raw)
-            except (TypeError, ValueError):
-                pass
-
-        teams_raw = details.get("teams") or {}
-
-        if not isinstance(teams_raw, dict) or not teams_raw:
-            continue
-
-        # 规范化：key 统一为字符串，value 仅保留 red/blue
-        norm_map: dict[str, str] = {}
-        for uid_key, colour in teams_raw.items():
-            if colour in ("red", "blue"):
-                norm_map[str(uid_key)] = colour
-
-        if not norm_map:
-            continue
-
-        if pid is not None:
-            try:
-                pid_teams[int(pid)] = norm_map
-            except (TypeError, ValueError):
-                pass
-
-        # 累积到全局兜底（后出现的覆盖先出现的，同房间队伍一般稳定）
-        fallback_teams.update(norm_map)
-
-    if not fallback_teams:
-        logger.debug(f"[team-map] room {match_id}: events 中未解析到 teams，降级 head-to-head")
-
-    if aborted_pids:
-        logger.debug(f"[team-map] room {match_id}: 检测到 {len(aborted_pids)} 局被强制关闭(abort)")
-
-    if pid_room_types:
-        logger.debug(
-            f"[team-map] room {match_id}: events 解析到 {len(pid_room_types)} 个 item 的模式"
-            f"（分布: {sorted(set(pid_room_types.values()))}）"
-        )
-
-    return pid_teams, (fallback_teams or None), aborted_pids, pid_room_types
-
-
-async def _convert_rooms_to_match_format(raw: dict, match_id: str) -> dict:
-    """
-    将 /api/v2/rooms/{id} 的响应转换为 Match schema 期望的 /matches/ 格式。
-
-    核心流程：
-      1. 构造 match 元信息
-      2. 收集用户信息
-      3. 从 events 接口获取 team 映射（红蓝分队）
-      4. 遍历 playlist，逐个请求 scores 并注入 team
-      5. 组装为 matches 格式
-    """
-
-    # ── 1. 构造 match 元信息 ──
-    match_meta = {
-        "id": raw.get("id"),
-        "name": raw.get("name", ""),
-        "start_time": raw.get("starts_at") or raw.get("created_at", ""),
-        "end_time": raw.get("ends_at"),
-    }
-
-    # ── 2. 收集用户信息 ──
-    users_dict: dict[int, dict] = {}
-
-    host = raw.get("host")
-    if host and host.get("id"):
-        users_dict[host["id"]] = host
-
-    for participant in raw.get("recent_participants", []):
-        uid = participant.get("id")
-        if uid and uid not in users_dict:
-            users_dict[uid] = participant
-
-    # ── 3. 获取 team 映射 + abort 局集合 + 每个 item 自己的房间模式 ──
-    # 注意：顶层 /rooms/{id} 的 type 字段有时不可靠（如 team-vs 房间可能返回
-    # head_to_head），且房间可能在运行中切换模式（热身 head_to_head → 正赛
-    # team_versus），因此以 events 接口每个 playlist item 的 details.room_type 为准。
-    fallback_room_type_raw = raw.get("type", "head_to_head")
-
-    # events 接口对所有模式都有用（abort 判定通用），team 模式额外拿分队
-    pid_teams: dict[int, dict[str, str]] = {}
-    fallback_teams: dict[str, str] | None = None
-    aborted_pids: set[int] = set()
-    pid_room_types: dict[int, str] = {}
-    pid_teams, fallback_teams, aborted_pids, pid_room_types = await _fetch_room_team_map(match_id)
-
-    # ── 4. 遍历 playlist，逐个请求 scores ──
-    playlist = raw.get("playlist", [])
-    events: list[dict] = []
-
-    for item in playlist:
-        if not item.get("played_at"):
-            continue
-
-        playlist_item_id = item["id"]
-
-        # ── 核心：跳过被强制关闭(abort)的对局 ──
-        # 依据 events 流里 event_type == "game_aborted" 精确判定。
-        if playlist_item_id in aborted_pids:
-            logger.debug(f"[rooms] playlist_item {playlist_item_id}: 被强制关闭(abort)，跳过")
-            continue
-
-        scores_url = f"https://osu.ppy.sh/api/v2/rooms/{match_id}/playlist/{playlist_item_id}/scores"
-
-        try:
-            scores_data = await api_info("matches", scores_url)
-        except Exception:
-            continue
-
-        scores_list = scores_data.get("scores", [])
-        if not scores_list:
-            continue
-
-        # 收集用户信息
-        for s in scores_list:
-            user_info = s.get("user")
-            if user_info:
-                uid = user_info.get("id")
-                if uid:
-                    if uid not in users_dict:
-                        users_dict[uid] = user_info
-
-        # ── 确定本 playlist item 自己的模式与 team 映射 ──
-        # 优先使用 events 解析出的该 item 模式；缺失时回退顶层 type。
-        item_room_type_raw = pid_room_types.get(playlist_item_id) or fallback_room_type_raw
-        item_room_type = _ROOM_TYPE_MAP.get(item_room_type_raw, item_room_type_raw)
-
-        team_map: dict[str, str] = {}
-        if item_room_type in ("team-vs", "tag-team-vs"):
-            team_map = pid_teams.get(playlist_item_id) or fallback_teams or {}
-
-        game_scores: list[dict] = []
-        # ── 只要 score 记录存在就计入（含 fail / HP 归零），并透传 passed ──
-        for s in scores_list:
-            uid_str = str(s.get("user_id", ""))
-            team_colour = team_map.get(uid_str, "none")
-            if team_colour not in ("red", "blue"):
-                team_colour = "none"
-
-            game_scores.append(
-                {
-                    "user_id": s.get("user_id"),
-                    "score": s.get("total_score", 0),
-                    "accuracy": s.get("accuracy", 0),
-                    "max_combo": s.get("max_combo", 0),
-                    "mods": _parse_mods(s.get("mods", [])),
-                    "match": {
-                        "team": team_colour,
-                        "passed": bool(s.get("passed", True)),  # ← 透传是否通过
-                    },
-                }
-            )
-
-        if not game_scores:
-            continue
-
-        beatmap_data = item.get("beatmap") or {}
-        beatmapset_data = beatmap_data.get("beatmapset") or {}
-        covers = beatmapset_data.get("covers") or {}
-
-        cover_url = covers.get("cover", "")
-        full_covers = {
-            "cover": cover_url,
-            "card": covers.get("card", cover_url),
-            "list": covers.get("list", cover_url),
-            "slimcover": covers.get("slimcover", cover_url),
-        }
-
-        game = {
-            "id": playlist_item_id,
-            "beatmap_id": item.get("beatmap_id"),
-            "team_type": item_room_type,
-            "mods": _parse_mods(item.get("required_mods", [])),
-            "beatmap": {
-                "id": beatmap_data.get("id"),
-                "mode": beatmap_data.get("mode", "osu"),
-                "status": beatmap_data.get("status", "ranked"),
-                "total_length": beatmap_data.get("total_length", 0),
-                "user_id": beatmap_data.get("user_id", 0),
-                "version": beatmap_data.get("version", ""),
-                "difficulty_rating": beatmap_data.get("difficulty_rating", 0),
-                "beatmapset_id": beatmap_data.get("beatmapset_id"),
-                "beatmapset": {
-                    "id": beatmapset_data.get("id", beatmap_data.get("beatmapset_id", 0)),
-                    "title": beatmapset_data.get("title", ""),
-                    "title_unicode": beatmapset_data.get("title_unicode", beatmapset_data.get("title", "")),
-                    "artist": beatmapset_data.get("artist", ""),
-                    "artist_unicode": beatmapset_data.get("artist_unicode", beatmapset_data.get("artist", "")),
-                    "creator": beatmapset_data.get("creator", ""),
-                    "user_id": beatmapset_data.get("user_id", 0),
-                    "source": beatmapset_data.get("source", ""),
-                    "status": beatmapset_data.get("status", "ranked"),
-                    "nsfw": beatmapset_data.get("nsfw", False),
-                    "video": beatmapset_data.get("video", False),
-                    "favourite_count": beatmapset_data.get("favourite_count", 0),
-                    "play_count": beatmapset_data.get("play_count", 0),
-                    "preview_url": beatmapset_data.get("preview_url", ""),
-                    "covers": full_covers,
-                },
-            },
-            "scores": game_scores,
-        }
-
-        events.append(
-            {
-                "id": playlist_item_id,
-                "detail": {"type": "other"},
-                "timestamp": item.get("played_at", ""),
-                "game": game,
-            }
-        )
-
-    return {
-        "match": match_meta,
-        "events": events,
-        "users": list(users_dict.values()),
-    }
-
-
 # ==================== 数据准备 & 渲染 ====================
 
 
-def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str | None = None) -> dict:
+def prepare_match_data(
+    match_info: Match,
+    match_id: str,
+    team_type_filter: str | None = None,
+    *,
+    include_failed_scores: bool = False,
+) -> dict:
     """将 Match 模型数据转换为模板渲染所需的字典。
 
     Parameters
@@ -507,26 +116,21 @@ def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str |
     for index, game in enumerate(games, start=1):
         beatmap = game.beatmap
         beatmapset = beatmap.beatmapset if beatmap else None
-        # 记录存在即计入（不再按分数过滤）
-        scores = [score for score in game.scores if score.user_id is not None]
+        scores = (
+            [score for score in game.scores if score.user_id is not None]
+            if include_failed_scores
+            else [score for score in game.scores if score.score > 0]
+        )
         if not scores:
             continue
 
         player_rows: list[dict] = []
         for score in sorted(scores, key=lambda item: item.score or 0, reverse=True):
             user = users.get(score.user_id)
-            # ── 队伍标签拼接逻辑 ──
-            if user:
-                team = getattr(user, "team", None)
-                tag = (getattr(team, "short_name", None) or getattr(team, "name", None)) if team else None
-                display_name = f"[{tag}] {user.username}" if tag else user.username
-            else:
-                display_name = str(score.user_id)
-            # ── 队伍标签拼接逻辑结束 ──
             player_rows.append(
                 {
                     "user_id": score.user_id,
-                    "name": display_name,
+                    "name": user.username if user else str(score.user_id),
                     "avatar": user.avatar_url if user else f"https://a.ppy.sh/{score.user_id}",
                     "team": (score.match or {}).get("team", "none"),
                     "passed": (score.match or {}).get("passed", True),
@@ -537,11 +141,16 @@ def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str |
                 }
             )
 
-        # ── 队伍总分：与 osu! 官方判定一致，只统计通过(passed)玩家的分数 ──
-        # 参考 osu-web resources/js/legacy-match/content.tsx：
-        #   if (!score.passed) continue; scores[team] += score.total_score;
-        red_score = sum(p["score"] for p in player_rows if p["team"] == "red" and p["passed"])
-        blue_score = sum(p["score"] for p in player_rows if p["team"] == "blue" and p["passed"])
+        red_score = sum(
+            player["score"]
+            for player in player_rows
+            if player["team"] == "red" and (player["passed"] or not include_failed_scores)
+        )
+        blue_score = sum(
+            player["score"]
+            for player in player_rows
+            if player["team"] == "blue" and (player["passed"] or not include_failed_scores)
+        )
         winner = "none"
         if red_score > blue_score:
             winner = "red"
@@ -618,7 +227,12 @@ async def draw_match_card(data: dict) -> bytes:
         return await element.screenshot(type="png")
 
 
-async def draw_match_history(match_id: str, query_type: str = "auto") -> list[bytes]:
+async def draw_match_history(
+    match_id: str,
+    query_type: str = "auto",
+    *,
+    return_data: bool = False,
+) -> list[bytes] | tuple[bytes, dict]:
     """
     绘制多人房/比赛历史记录图片（入口函数）。
 
@@ -660,8 +274,9 @@ async def draw_match_history(match_id: str, query_type: str = "auto") -> list[by
         raise OsubotNetworkError(f"未找到 ID 为 {match_id} 的比赛/多人房，请检查 ID 是否正确。")
 
     # ── Step 2: 如果是 rooms 格式，转换为 matches 格式 ──
-    if source == "rooms" or _is_rooms_response(raw):
-        raw = await _convert_rooms_to_match_format(raw, match_id)
+    is_room = source == "rooms" or is_room_response(raw)
+    if is_room:
+        raw = await convert_room_to_match(raw, match_id)
 
     # ── Step 3: 按模式分组渲染 ──
     # 房间可能在运行中切换模式（如热身 head-to-head → 正赛 team-vs），
@@ -676,14 +291,22 @@ async def draw_match_history(match_id: str, query_type: str = "auto") -> list[by
         raise ValueError("该多人房没有可展示的对局")
 
     # 找出实际存在的模式（保持稳定顺序：team 类在前，其余在后）
-    mode_set: set[str] = {game.team_type for game in all_games}
-    team_modes = [m for m in ("team-vs", "tag-team-vs") if m in mode_set]
-    other_modes = [m for m in mode_set if m not in ("team-vs", "tag-team-vs")]
+    modes = list(dict.fromkeys(game.team_type for game in all_games))
+    team_modes = [mode_type for mode_type in ("team-vs", "tag-team-vs") if mode_type in modes]
+    other_modes = [mode_type for mode_type in modes if mode_type not in ("team-vs", "tag-team-vs")]
     ordered_modes = team_modes + other_modes
 
     pages: list[bytes] = []
+    first_data: dict | None = None
     for mode_type in ordered_modes:
-        data = prepare_match_data(match_info, match_id, team_type_filter=mode_type)
+        data = prepare_match_data(
+            match_info,
+            match_id,
+            team_type_filter=mode_type,
+            include_failed_scores=is_room,
+        )
+        if first_data is None:
+            first_data = data
         chunks = _chunk_games(data["games"])
         page_count = len(chunks)
         for page_index, chunk in enumerate(chunks, start=1):
@@ -694,6 +317,8 @@ async def draw_match_history(match_id: str, query_type: str = "auto") -> list[by
                 "page_count": page_count,
             }
             img = await draw_match_card(page_data)
-            pages.append(_compress_image(img))
+            pages.append(compress_jpeg(img))
 
+    if return_data:
+        return pages[0], first_data or {}
     return pages

--- a/src/nonebot_plugin_osubot/draw/match_history.py
+++ b/src/nonebot_plugin_osubot/draw/match_history.py
@@ -1,3 +1,4 @@
+import io
 import re
 from pathlib import Path
 from datetime import datetime
@@ -5,16 +6,39 @@ from statistics import mode
 
 import jinja2
 
+try:  # Pillow 可选依赖：用于压缩图片；未安装时自动回退为原图
+    from PIL import Image
+
+    _HAS_PIL = True
+except ImportError:  # pragma: no cover
+    _HAS_PIL = False
+
 from ..api import api_info
 from ..schema.match import Match
-from .browser import persistent_page, wait_for_page_assets
+from .browser import persistent_page
+from nonebot.log import logger
 
 
 TEMPLATE_PATH = Path(__file__).parent / "match_templates"
 MOD_PATH = Path(__file__).parent.parent / "osufile" / "mods"
 
+# ============ 分页 / 压缩配置（可按需调整） ============
+MAX_ROWS_PER_PAGE = 32
+MAX_IMAGE_WIDTH = 1200
+JPEG_QUALITY = 85
+BG_COLOR = (13, 13, 20)
+
+# ============ Rooms API type → Match schema team_type 映射 ============
+_ROOM_TYPE_MAP: dict[str, str] = {
+    "team_versus": "team-vs",
+    "head_to_head": "head-to-head",
+    "tag_coop": "tag-coop",
+    "tag_team_vs": "tag-team-vs",
+}
+
 
 def _score_mods(game_mods: list[str], player_mods: list[str]) -> list[str]:
+    """合并游戏级 mods 与玩家级 mods，去重并过滤无效/不显示项"""
     mods = list(dict.fromkeys([*game_mods, *player_mods]))
     if "NC" in mods and "DT" in mods:
         mods.remove("DT")
@@ -22,6 +46,7 @@ def _score_mods(game_mods: list[str], player_mods: list[str]) -> list[str]:
 
 
 def _match_names(name: str) -> tuple[str, str, str]:
+    """从房间名中解析标题和红蓝队名称"""
     matched = re.search(r"([^:]+): [\(（](.+?)[\)）] vs [\(（](.+?)[\)）]", name, re.IGNORECASE)
     if not matched:
         return name, "红队", "蓝队"
@@ -29,6 +54,7 @@ def _match_names(name: str) -> tuple[str, str, str]:
 
 
 def _format_time_range(match: dict) -> tuple[str, str]:
+    """格式化比赛时间范围和持续时间文本"""
     start = datetime.fromisoformat(match["start_time"])
     end_value = match.get("end_time")
     if not end_value:
@@ -41,49 +67,492 @@ def _format_time_range(match: dict) -> tuple[str, str]:
     return f"{start:%Y/%m/%d %H:%M}—{end:%H:%M}", duration_text
 
 
-def prepare_match_data(match_info: Match, match_id: str) -> dict:
-    games = [
+def _chunk_games(games: list[dict], max_rows: int = MAX_ROWS_PER_PAGE) -> list[list[dict]]:
+    """按最大行数将 games 列表分页"""
+    chunks: list[dict] = []
+    current: list[dict] = []
+    rows = 0
+    for game in games:
+        n = len(game["players"])
+        if current and rows + n > max_rows:
+            chunks.append(current)
+            current, rows = [], 0
+        current.append(game)
+        rows += n
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _compress_image(img_bytes: bytes) -> bytes:
+    """使用 Pillow 压缩截图；未安装或失败时返回原图"""
+    if not _HAS_PIL:
+        return img_bytes
+    try:
+        im = Image.open(io.BytesIO(img_bytes))
+        if im.width > MAX_IMAGE_WIDTH:
+            ratio = MAX_IMAGE_WIDTH / im.width
+            im = im.resize((MAX_IMAGE_WIDTH, int(im.height * ratio)), Image.LANCZOS)
+        if im.mode != "RGB":
+            background = Image.new("RGB", im.size, BG_COLOR)
+            im = im.convert("RGBA")
+            background.paste(im, mask=im.split()[-1])
+            im = background
+        buf = io.BytesIO()
+        im.save(buf, format="JPEG", quality=JPEG_QUALITY, optimize=True)
+        return buf.getvalue()
+    except Exception:
+        return img_bytes
+
+
+def _merge_images_vertically(pages: list[bytes]) -> bytes:
+    """将多页图片纵向拼接为一张长图"""
+    if not _HAS_PIL or len(pages) <= 1:
+        return pages[0] if pages else b""
+    try:
+        images = [Image.open(io.BytesIO(p)) for p in pages]
+        total_width = max(im.width for im in images)
+        total_height = sum(im.height for im in images)
+        merged = Image.new("RGB", (total_width, total_height), BG_COLOR)
+        y_offset = 0
+        for im in images:
+            if im.mode != "RGB":
+                bg = Image.new("RGB", im.size, BG_COLOR)
+                bg.paste(im, mask=im.split()[-1])
+                im = bg
+            merged.paste(im, (0, y_offset))
+            y_offset += im.height
+        buf = io.BytesIO()
+        merged.save(buf, format="JPEG", quality=JPEG_QUALITY, optimize=True)
+        return buf.getvalue()
+    except Exception:
+        return pages[0]
+
+
+# ==================== Rooms API 适配层 ====================
+
+
+def _is_rooms_response(raw: dict) -> bool:
+    """
+    判断 API 返回的是 /rooms/ 格式还是 /matches/ 格式。
+
+    /matches/ 响应一定有顶层 "match" 键；
+    /rooms/ 响应有 "playlist" 或 "category" 键，且没有 "match"。
+    """
+    return "match" not in raw and ("playlist" in raw or "category" in raw)
+
+
+def _parse_mods(raw_mods: list) -> list[str]:
+    """
+    将 osu! API v2 返回的 mods 列表统一为 acronym 字符串列表。
+
+    API 可能返回两种格式：
+      - 字符串列表: ["HD", "DT"]
+      - 对象列表:   [{"acronym": "HD", ...}, {"acronym": "DT", ...}]
+    """
+    result: list[str] = []
+    for m in raw_mods:
+        if isinstance(m, dict):
+            acronym = m.get("acronym", "")
+            if acronym:
+                result.append(acronym)
+        elif isinstance(m, str) and m:
+            result.append(m)
+    return result
+
+
+async def _fetch_room_team_map(
+    match_id: str,
+) -> tuple[dict[int, dict[str, str]], dict[str, str] | None, set[int], dict[int, str]]:
+    """
+    从 /api/v2/rooms/{id}/events 接口解析：
+      1. 每个 playlist item 的红蓝分队映射
+      2. 被强制关闭(abort)的 playlist_item_id 集合
+      3. 每个 playlist item 自己的真实模式（details.room_type）
+
+    osu! 官方页面渲染 --red/--blue 的数据来源就是 events 接口里
+    每个 playlist_item.details.teams，结构为：
+        { "user_id字符串": "red" | "blue" }
+
+    注意：同一房间可能在运行中切换模式（如先 head_to_head 热身、后 team_versus
+    正赛），因此**每个 playlist item 单独记录自己的 room_type**，顶层 /rooms/{id}
+    的 type 字段只作为兜底。
+
+    而被强制关闭的对局在 events 流里有 event_type == "game_aborted"
+    （正常完成的是 "game_completed"），据此可精确剔除 abort 局。
+
+    Returns
+    -------
+    pid_teams : dict[int, dict[str, str]]
+        按 playlist_item_id 索引的精确队伍映射：{ pid: { uid_str: "red"/"blue" } }
+    fallback_teams : dict[str, str] | None
+        全局兜底映射（合并所有 item 的 teams），用于无法精确匹配 pid 的场景。
+        解析失败时返回 None。
+    aborted_pids : set[int]
+        被强制关闭(game_aborted)的 playlist_item_id 集合。
+    pid_room_types : dict[int, str]
+        按 playlist_item_id 索引的房间模式（原始值如 "team_versus"/"head_to_head"），
+        该 item 解析不到时不存在于字典中。
+    """
+    events_url = f"https://osu.ppy.sh/api/v2/rooms/{match_id}/events"
+
+    pid_teams: dict[int, dict[str, str]] = {}
+    fallback_teams: dict[str, str] = {}
+    aborted_pids: set[int] = set()
+    pid_room_types: dict[int, str] = {}
+
+    try:
+        events_data = await api_info("matches", events_url)
+    except Exception as exc:
+        logger.debug(f"[team-map] room {match_id}: 请求 events 失败，降级 head-to-head ({exc})")
+        return {}, None, set(), {}
+
+    # ── 从 events 流提取 game_aborted 的 playlist_item_id ──
+    raw_events: list = []
+    if isinstance(events_data, dict):
+        raw_events = events_data.get("events", []) or []
+    for ev in raw_events:
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("event_type") == "game_aborted":
+            pid = ev.get("playlist_item_id")
+            if pid is not None:
+                try:
+                    aborted_pids.add(int(pid))
+                except (TypeError, ValueError):
+                    pass
+
+    # events 接口的 playlist items 可能在 "playlist" 或 "events" 里，做兼容
+    playlist_items: list[dict] = []
+    if isinstance(events_data, dict):
+        playlist_items = events_data.get("playlist") or events_data.get("playlist_items") or []
+        # 部分版本 events 是事件流，playlist item 嵌在 event.playlist_item 里
+        if not playlist_items:
+            for ev in raw_events:
+                pi = ev.get("playlist_item") if isinstance(ev, dict) else None
+                if isinstance(pi, dict):
+                    playlist_items.append(pi)
+
+    for item in playlist_items:
+        if not isinstance(item, dict):
+            continue
+        pid = item.get("id")
+        details = item.get("details") or {}
+
+        # ── 记录该 item 自己的房间模式 ──
+        rt_raw = details.get("room_type")
+        if rt_raw and pid is not None:
+            try:
+                pid_room_types[int(pid)] = str(rt_raw)
+            except (TypeError, ValueError):
+                pass
+
+        teams_raw = details.get("teams") or {}
+
+        if not isinstance(teams_raw, dict) or not teams_raw:
+            continue
+
+        # 规范化：key 统一为字符串，value 仅保留 red/blue
+        norm_map: dict[str, str] = {}
+        for uid_key, colour in teams_raw.items():
+            if colour in ("red", "blue"):
+                norm_map[str(uid_key)] = colour
+
+        if not norm_map:
+            continue
+
+        if pid is not None:
+            try:
+                pid_teams[int(pid)] = norm_map
+            except (TypeError, ValueError):
+                pass
+
+        # 累积到全局兜底（后出现的覆盖先出现的，同房间队伍一般稳定）
+        fallback_teams.update(norm_map)
+
+    if not fallback_teams:
+        logger.debug(f"[team-map] room {match_id}: events 中未解析到 teams，降级 head-to-head")
+
+    if aborted_pids:
+        logger.debug(f"[team-map] room {match_id}: 检测到 {len(aborted_pids)} 局被强制关闭(abort)")
+
+    if pid_room_types:
+        logger.debug(
+            f"[team-map] room {match_id}: events 解析到 {len(pid_room_types)} 个 item 的模式"
+            f"（分布: {sorted(set(pid_room_types.values()))}）"
+        )
+
+    return pid_teams, (fallback_teams or None), aborted_pids, pid_room_types
+
+
+async def _convert_rooms_to_match_format(raw: dict, match_id: str) -> dict:
+    """
+    将 /api/v2/rooms/{id} 的响应转换为 Match schema 期望的 /matches/ 格式。
+
+    核心流程：
+      1. 构造 match 元信息
+      2. 收集用户信息
+      3. 从 events 接口获取 team 映射（红蓝分队）
+      4. 遍历 playlist，逐个请求 scores 并注入 team
+      5. 组装为 matches 格式
+    """
+
+    # ── 1. 构造 match 元信息 ──
+    match_meta = {
+        "id": raw.get("id"),
+        "name": raw.get("name", ""),
+        "start_time": raw.get("starts_at") or raw.get("created_at", ""),
+        "end_time": raw.get("ends_at"),
+    }
+
+    # ── 2. 收集用户信息 ──
+    users_dict: dict[int, dict] = {}
+
+    host = raw.get("host")
+    if host and host.get("id"):
+        users_dict[host["id"]] = host
+
+    for participant in raw.get("recent_participants", []):
+        uid = participant.get("id")
+        if uid and uid not in users_dict:
+            users_dict[uid] = participant
+
+    # ── 3. 获取 team 映射 + abort 局集合 + 每个 item 自己的房间模式 ──
+    # 注意：顶层 /rooms/{id} 的 type 字段有时不可靠（如 team-vs 房间可能返回
+    # head_to_head），且房间可能在运行中切换模式（热身 head_to_head → 正赛
+    # team_versus），因此以 events 接口每个 playlist item 的 details.room_type 为准。
+    fallback_room_type_raw = raw.get("type", "head_to_head")
+
+    # events 接口对所有模式都有用（abort 判定通用），team 模式额外拿分队
+    pid_teams: dict[int, dict[str, str]] = {}
+    fallback_teams: dict[str, str] | None = None
+    aborted_pids: set[int] = set()
+    pid_room_types: dict[int, str] = {}
+    pid_teams, fallback_teams, aborted_pids, pid_room_types = await _fetch_room_team_map(match_id)
+
+    # ── 4. 遍历 playlist，逐个请求 scores ──
+    playlist = raw.get("playlist", [])
+    events: list[dict] = []
+
+    for item in playlist:
+        if not item.get("played_at"):
+            continue
+
+        playlist_item_id = item["id"]
+
+        # ── 核心：跳过被强制关闭(abort)的对局 ──
+        # 依据 events 流里 event_type == "game_aborted" 精确判定。
+        if playlist_item_id in aborted_pids:
+            logger.debug(f"[rooms] playlist_item {playlist_item_id}: 被强制关闭(abort)，跳过")
+            continue
+
+        scores_url = (
+            f"https://osu.ppy.sh/api/v2/rooms/{match_id}"
+            f"/playlist/{playlist_item_id}/scores"
+        )
+
+        try:
+            scores_data = await api_info("matches", scores_url)
+        except Exception:
+            continue
+
+        scores_list = scores_data.get("scores", [])
+        if not scores_list:
+            continue
+
+        # 收集用户信息
+        for s in scores_list:
+            user_info = s.get("user")
+            if user_info:
+                uid = user_info.get("id")
+                if uid:
+                    if uid not in users_dict:
+                        users_dict[uid] = user_info
+
+        # ── 确定本 playlist item 自己的模式与 team 映射 ──
+        # 优先使用 events 解析出的该 item 模式；缺失时回退顶层 type。
+        item_room_type_raw = pid_room_types.get(playlist_item_id) or fallback_room_type_raw
+        item_room_type = _ROOM_TYPE_MAP.get(item_room_type_raw, item_room_type_raw)
+
+        team_map: dict[str, str] = {}
+        if item_room_type in ("team-vs", "tag-team-vs"):
+            team_map = pid_teams.get(playlist_item_id) or fallback_teams or {}
+
+        game_scores: list[dict] = []
+        # ── 只要 score 记录存在就计入（含 fail / HP 归零），并透传 passed ──
+        for s in scores_list:
+            uid_str = str(s.get("user_id", ""))
+            team_colour = team_map.get(uid_str, "none")
+            if team_colour not in ("red", "blue"):
+                team_colour = "none"
+
+            game_scores.append({
+                "user_id": s.get("user_id"),
+                "score": s.get("total_score", 0),
+                "accuracy": s.get("accuracy", 0),
+                "max_combo": s.get("max_combo", 0),
+                "mods": _parse_mods(s.get("mods", [])),
+                "match": {
+                    "team": team_colour,
+                    "passed": bool(s.get("passed", True)),  # ← 透传是否通过
+                },
+            })
+
+        if not game_scores:
+            continue
+
+        beatmap_data = item.get("beatmap") or {}
+        beatmapset_data = beatmap_data.get("beatmapset") or {}
+        covers = beatmapset_data.get("covers") or {}
+
+        cover_url = covers.get("cover", "")
+        full_covers = {
+            "cover": cover_url,
+            "card": covers.get("card", cover_url),
+            "list": covers.get("list", cover_url),
+            "slimcover": covers.get("slimcover", cover_url),
+        }
+
+        game = {
+            "id": playlist_item_id,
+            "beatmap_id": item.get("beatmap_id"),
+            "team_type": item_room_type,
+            "mods": _parse_mods(item.get("required_mods", [])),
+            "beatmap": {
+                "id": beatmap_data.get("id"),
+                "mode": beatmap_data.get("mode", "osu"),
+                "status": beatmap_data.get("status", "ranked"),
+                "total_length": beatmap_data.get("total_length", 0),
+                "user_id": beatmap_data.get("user_id", 0),
+                "version": beatmap_data.get("version", ""),
+                "difficulty_rating": beatmap_data.get("difficulty_rating", 0),
+                "beatmapset_id": beatmap_data.get("beatmapset_id"),
+                "beatmapset": {
+                    "id": beatmapset_data.get("id", beatmap_data.get("beatmapset_id", 0)),
+                    "title": beatmapset_data.get("title", ""),
+                    "title_unicode": beatmapset_data.get("title_unicode", beatmapset_data.get("title", "")),
+                    "artist": beatmapset_data.get("artist", ""),
+                    "artist_unicode": beatmapset_data.get("artist_unicode", beatmapset_data.get("artist", "")),
+                    "creator": beatmapset_data.get("creator", ""),
+                    "user_id": beatmapset_data.get("user_id", 0),
+                    "source": beatmapset_data.get("source", ""),
+                    "status": beatmapset_data.get("status", "ranked"),
+                    "nsfw": beatmapset_data.get("nsfw", False),
+                    "video": beatmapset_data.get("video", False),
+                    "favourite_count": beatmapset_data.get("favourite_count", 0),
+                    "play_count": beatmapset_data.get("play_count", 0),
+                    "preview_url": beatmapset_data.get("preview_url", ""),
+                    "covers": full_covers,
+                },
+            },
+            "scores": game_scores,
+        }
+
+        events.append({
+            "id": playlist_item_id,
+            "detail": {"type": "other"},
+            "timestamp": item.get("played_at", ""),
+            "game": game,
+        })
+
+    return {
+        "match": match_meta,
+        "events": events,
+        "users": list(users_dict.values()),
+    }
+
+
+# ==================== 数据准备 & 渲染 ====================
+
+
+def prepare_match_data(match_info: Match, match_id: str, team_type_filter: str | None = None) -> dict:
+    """将 Match 模型数据转换为模板渲染所需的字典。
+
+    Parameters
+    ----------
+    team_type_filter : str | None
+        只取该模式的 games 渲染（如 "team-vs" / "head-to-head"）。
+        用于房间中途切换模式的场景，把不同模式的对局分开渲染。
+    """
+    all_games = [
         event.game
         for event in match_info.events
-        if event.detail.type == "other" and event.game is not None and event.game.scores
+        if event.detail.type == "other"
+        and event.game is not None
+        and event.game.scores
     ]
-    if not games:
+    if not all_games:
         raise ValueError("该多人房没有可展示的对局")
 
-    team_type = mode([game.team_type for game in games])
-    is_team = team_type == "team-vs"
+    if team_type_filter:
+        games = [game for game in all_games if game.team_type == team_type_filter]
+        if not games:
+            raise ValueError(f"该多人房没有 {team_type_filter} 模式的对局")
+    else:
+        games = all_games
+
+    team_type = team_type_filter or mode([game.team_type for game in games])
+    is_team = team_type in ("team-vs", "tag-team-vs")
+    if is_team:
+        _has_team = any(
+            (score.match or {}).get("team") in ("red", "blue")
+            for game in games
+            for score in game.scores
+        )
+        if not _has_team:
+            team_type = "head-to-head"
+            is_team = False
     users = {user.id: user for user in match_info.users}
     title, red_name, blue_name = _match_names(match_info.match["name"])
     time_range, duration = _format_time_range(match_info.match)
     red_wins = 0
     blue_wins = 0
-    rendered_games = []
+    rendered_games: list[dict] = []
 
     for index, game in enumerate(games, start=1):
         beatmap = game.beatmap
         beatmapset = beatmap.beatmapset if beatmap else None
-        scores = [score for score in game.scores if score.score > 0]
+        # 记录存在即计入（不再按分数过滤）
+        scores = [score for score in game.scores if score.user_id is not None]
         if not scores:
             continue
 
-        player_rows = []
-        for score in sorted(scores, key=lambda item: item.score, reverse=True):
+        player_rows: list[dict] = []
+        for score in sorted(scores, key=lambda item: item.score or 0, reverse=True):
             user = users.get(score.user_id)
-            player_rows.append(
-                {
-                    "user_id": score.user_id,
-                    "name": user.username if user else str(score.user_id),
-                    "avatar": user.avatar_url if user else f"https://a.ppy.sh/{score.user_id}",
-                    "team": (score.match or {}).get("team", "none"),
-                    "score": score.score,
-                    "accuracy": score.accuracy * 100,
-                    "combo": score.max_combo,
-                    "mods": _score_mods(game.mods, score.mods),
-                }
-            )
+            # ── 队伍标签拼接逻辑 ──
+            if user:
+                team = getattr(user, "team", None)
+                tag = (
+                    getattr(team, "short_name", None) or getattr(team, "name", None)
+                ) if team else None
+                display_name = f"[{tag}] {user.username}" if tag else user.username
+            else:
+                display_name = str(score.user_id)
+            # ── 队伍标签拼接逻辑结束 ──
+            player_rows.append({
+                "user_id": score.user_id,
+                "name": display_name,
+                "avatar": user.avatar_url if user else f"https://a.ppy.sh/{score.user_id}",
+                "team": (score.match or {}).get("team", "none"),
+                "passed": (score.match or {}).get("passed", True),
+                "score": score.score or 0,
+                "accuracy": (score.accuracy or 0) * 100,
+                "combo": score.max_combo or 0,
+                "mods": _score_mods(game.mods, score.mods),
+            })
 
-        red_score = sum(player["score"] for player in player_rows if player["team"] == "red")
-        blue_score = sum(player["score"] for player in player_rows if player["team"] == "blue")
+        # ── 队伍总分：与 osu! 官方判定一致，只统计通过(passed)玩家的分数 ──
+        # 参考 osu-web resources/js/legacy-match/content.tsx：
+        #   if (!score.passed) continue; scores[team] += score.total_score;
+        red_score = sum(
+            p["score"] for p in player_rows
+            if p["team"] == "red" and p["passed"]
+        )
+        blue_score = sum(
+            p["score"] for p in player_rows
+            if p["team"] == "blue" and p["passed"]
+        )
         winner = "none"
         if red_score > blue_score:
             winner = "red"
@@ -92,29 +561,29 @@ def prepare_match_data(match_info: Match, match_id: str) -> dict:
             winner = "blue"
             blue_wins += 1
 
-        rendered_games.append(
-            {
-                "index": index,
-                "map_id": game.beatmap_id,
-                "title": beatmapset.title if beatmapset else f"Beatmap {game.beatmap_id}",
-                "version": beatmap.version if beatmap else "Unknown Difficulty",
-                "creator": beatmapset.creator if beatmapset else "unknown",
-                "cover": (
-                    beatmapset.covers.cover
-                    if beatmapset
-                    else f"https://assets.ppy.sh/beatmaps/{beatmap.beatmapset_id}/covers/cover.jpg"
+        rendered_games.append({
+            "index": index,
+            "map_id": game.beatmap_id,
+            "title": beatmapset.title if beatmapset else f"Beatmap {game.beatmap_id}",
+            "version": beatmap.version if beatmap else "Unknown Difficulty",
+            "creator": beatmapset.creator if beatmapset else "unknown",
+            "cover": (
+                beatmapset.covers.cover
+                if beatmapset
+                else (
+                    f"https://assets.ppy.sh/beatmaps/{beatmap.beatmapset_id}/covers/cover.jpg"
                     if beatmap
                     else ""
-                ),
-                "stars": beatmap.difficulty_rating if beatmap else 0,
-                "winner": winner,
-                "red_score": red_score,
-                "blue_score": blue_score,
-                "players": player_rows,
-                "red_players": [player for player in player_rows if player["team"] == "red"],
-                "blue_players": [player for player in player_rows if player["team"] == "blue"],
-            }
-        )
+                )
+            ),
+            "stars": beatmap.difficulty_rating if beatmap else 0,
+            "winner": winner,
+            "red_score": red_score,
+            "blue_score": blue_score,
+            "players": player_rows,
+            "red_players": [p for p in player_rows if p["team"] == "red"],
+            "blue_players": [p for p in player_rows if p["team"] == "blue"],
+        })
 
     if not rendered_games:
         raise ValueError("该多人房没有有效成绩")
@@ -129,9 +598,13 @@ def prepare_match_data(match_info: Match, match_id: str) -> dict:
         "red_wins": red_wins,
         "blue_wins": blue_wins,
         "game_count": len(rendered_games),
-        "player_count": len({player["user_id"] for game in rendered_games for player in game["players"]}),
+        "player_count": len({
+            player["user_id"]
+            for game in rendered_games
+            for player in game["players"]
+        }),
         "team_size": max(
-            (max(len(game["red_players"]), len(game["blue_players"])) for game in rendered_games),
+            (max(len(g["red_players"]), len(g["blue_players"])) for g in rendered_games),
             default=0,
         ),
         "duration": duration,
@@ -142,27 +615,111 @@ def prepare_match_data(match_info: Match, match_id: str) -> dict:
 
 
 async def draw_match_card(data: dict) -> bytes:
+    """使用 Jinja2 + Playwright 渲染单页比赛卡片并截图"""
     template = jinja2.Environment(  # noqa: S701
         loader=jinja2.FileSystemLoader(str(TEMPLATE_PATH)), enable_async=True
     ).get_template("index.html")
     async with persistent_page(
-        "match_history", (TEMPLATE_PATH / "index.html").as_uri(), {"width": 1280, "height": 900}
+        "match_history",
+        (TEMPLATE_PATH / "index.html").as_uri(),
+        {"width": 1280, "height": 900},
     ) as page:
-        await page.set_content(await template.render_async(**data), wait_until="domcontentloaded")
-        await wait_for_page_assets(page)
+        await page.set_content(
+            await template.render_async(**data), wait_until="domcontentloaded"
+        )
+        await page.evaluate(
+            "Promise.race([Promise.all([document.fonts.ready,"
+            "...Array.from(document.images,x=>x.decode().catch(()=>{}))]),"
+            "new Promise(resolve=>setTimeout(resolve,8000))])"
+        )
         element = await page.query_selector(".card")
         assert element
         return await element.screenshot(type="png")
 
 
-async def draw_match_history(
-    match_id: str,
-    *,
-    return_data: bool = False,
-) -> bytes | tuple[bytes, dict]:
-    raw = await api_info("matches", f"https://osu.ppy.sh/api/v2/matches/{match_id}")
-    data = prepare_match_data(Match(**raw), match_id)
-    image = await draw_match_card(data)
-    if return_data:
-        return image, data
-    return image
+async def draw_match_history(match_id: str, query_type: str = "auto") -> list[bytes]:
+    """
+    绘制多人房/比赛历史记录图片（入口函数）。
+
+    Parameters
+    ----------
+    match_id : str
+        比赛 ID 或多人房 ID。
+    query_type : str
+        "match" — 仅查询 /matches/ API（传统 mp lobby）
+        "room"  — 仅查询 /rooms/ API（osu!lazer multiplayer room）
+        "auto"  — 先试 matches，失败再试 rooms（默认）
+
+    Returns
+    -------
+    list[bytes]
+        每页一张 PNG/JPEG 图片字节。
+    """
+    raw = None
+    source = None  # "matches" | "rooms"
+
+    # ── Step 1: 尝试获取原始数据 ──
+    if query_type in ("match", "auto"):
+        try:
+            raw = await api_info(
+                "matches", f"https://osu.ppy.sh/api/v2/matches/{match_id}"
+            )
+            source = "matches"
+        except Exception:
+            raw = None
+
+    if raw is None and query_type in ("room", "auto"):
+        try:
+            raw = await api_info(
+                "matches", f"https://osu.ppy.sh/api/v2/rooms/{match_id}"
+            )
+            source = "rooms"
+        except Exception:
+            raw = None
+
+    if raw is None:
+        from ..exceptions import NetworkError as OsubotNetworkError
+        raise OsubotNetworkError(
+            f"未找到 ID 为 {match_id} 的比赛/多人房，请检查 ID 是否正确。"
+        )
+
+    # ── Step 2: 如果是 rooms 格式，转换为 matches 格式 ──
+    if source == "rooms" or _is_rooms_response(raw):
+        raw = await _convert_rooms_to_match_format(raw, match_id)
+
+    # ── Step 3: 按模式分组渲染 ──
+    # 房间可能在运行中切换模式（如热身 head-to-head → 正赛 team-vs），
+    # 每种模式分别渲染一张（或多张分页）图片。
+    match_info = Match(**raw)
+    all_games = [
+        event.game
+        for event in match_info.events
+        if event.detail.type == "other"
+        and event.game is not None
+        and event.game.scores
+    ]
+    if not all_games:
+        raise ValueError("该多人房没有可展示的对局")
+
+    # 找出实际存在的模式（保持稳定顺序：team 类在前，其余在后）
+    mode_set: set[str] = {game.team_type for game in all_games}
+    team_modes = [m for m in ("team-vs", "tag-team-vs") if m in mode_set]
+    other_modes = [m for m in mode_set if m not in ("team-vs", "tag-team-vs")]
+    ordered_modes = team_modes + other_modes
+
+    pages: list[bytes] = []
+    for mode_type in ordered_modes:
+        data = prepare_match_data(match_info, match_id, team_type_filter=mode_type)
+        chunks = _chunk_games(data["games"])
+        page_count = len(chunks)
+        for page_index, chunk in enumerate(chunks, start=1):
+            page_data = {
+                **data,
+                "games": chunk,
+                "page_index": page_index,
+                "page_count": page_count,
+            }
+            img = await draw_match_card(page_data)
+            pages.append(_compress_image(img))
+
+    return pages

--- a/src/nonebot_plugin_osubot/draw/match_history.py
+++ b/src/nonebot_plugin_osubot/draw/match_history.py
@@ -51,7 +51,7 @@ def _format_time_range(match: dict) -> tuple[str, str]:
 
 def _chunk_games(games: list[dict], max_rows: int = MAX_ROWS_PER_PAGE) -> list[list[dict]]:
     """按最大行数将 games 列表分页"""
-    chunks: list[dict] = []
+    chunks: list[list[dict]] = []
     current: list[dict] = []
     rows = 0
     for game in games:
@@ -297,7 +297,6 @@ async def draw_match_history(
     ordered_modes = team_modes + other_modes
 
     pages: list[bytes] = []
-    first_data: dict | None = None
     for mode_type in ordered_modes:
         data = prepare_match_data(
             match_info,
@@ -305,10 +304,21 @@ async def draw_match_history(
             team_type_filter=mode_type,
             include_failed_scores=is_room,
         )
-        if first_data is None:
-            first_data = data
         chunks = _chunk_games(data["games"])
         page_count = len(chunks)
+
+        # agent_tools 的兼容入口只消费一张图片和结构化数据；避免把其余页面
+        # 都交给 Playwright 渲染后再丢弃。
+        if return_data:
+            page_data = {
+                **data,
+                "games": chunks[0],
+                "page_index": 1,
+                "page_count": page_count,
+            }
+            img = await draw_match_card(page_data)
+            return compress_jpeg(img), data
+
         for page_index, chunk in enumerate(chunks, start=1):
             page_data = {
                 **data,
@@ -319,6 +329,4 @@ async def draw_match_history(
             img = await draw_match_card(page_data)
             pages.append(compress_jpeg(img))
 
-    if return_data:
-        return pages[0], first_data or {}
     return pages

--- a/src/nonebot_plugin_osubot/match_room.py
+++ b/src/nonebot_plugin_osubot/match_room.py
@@ -1,0 +1,227 @@
+from dataclasses import dataclass, field
+
+from nonebot.log import logger
+
+from .api import api_info
+from .schema.match import normalize_mods
+from .utils import FGM
+
+_ROOM_TYPE_MAP = {
+    "team_versus": "team-vs",
+    "head_to_head": "head-to-head",
+    "tag_coop": "tag-coop",
+    "tag_team_vs": "tag-team-vs",
+}
+
+
+@dataclass
+class RoomEventMetadata:
+    teams_by_playlist: dict[int, dict[str, str]] = field(default_factory=dict)
+    fallback_teams: dict[str, str] = field(default_factory=dict)
+    aborted_playlist_ids: set[int] = field(default_factory=set)
+    room_types_by_playlist: dict[int, str] = field(default_factory=dict)
+
+
+def is_room_response(raw: dict) -> bool:
+    """Return whether an osu! API response uses the lazer room shape."""
+    return "match" not in raw and ("playlist" in raw or "category" in raw)
+
+
+async def fetch_room_event_metadata(room_id: str) -> RoomEventMetadata:
+    """Load team, abort, and mode metadata for every room playlist item."""
+    metadata = RoomEventMetadata()
+    try:
+        events_data = await api_info("matches", f"https://osu.ppy.sh/api/v2/rooms/{room_id}/events")
+    except Exception as exc:
+        logger.debug(f"[room-events] room {room_id}: request failed, using room defaults ({exc})")
+        return metadata
+
+    if not isinstance(events_data, dict):
+        return metadata
+
+    events = events_data.get("events") or []
+    for event in events:
+        if not isinstance(event, dict) or event.get("event_type") != "game_aborted":
+            continue
+        playlist_id = event.get("playlist_item_id")
+        try:
+            metadata.aborted_playlist_ids.add(int(playlist_id))
+        except (TypeError, ValueError):
+            continue
+
+    playlist_items = events_data.get("playlist") or events_data.get("playlist_items") or []
+    if not playlist_items:
+        playlist_items = [
+            event["playlist_item"]
+            for event in events
+            if isinstance(event, dict) and isinstance(event.get("playlist_item"), dict)
+        ]
+
+    for item in playlist_items:
+        if not isinstance(item, dict):
+            continue
+        try:
+            playlist_id = int(item["id"])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        details = item.get("details") or {}
+        if room_type := details.get("room_type"):
+            metadata.room_types_by_playlist[playlist_id] = str(room_type)
+
+        teams = {
+            str(user_id): colour
+            for user_id, colour in (details.get("teams") or {}).items()
+            if colour in {"red", "blue"}
+        }
+        if teams:
+            metadata.teams_by_playlist[playlist_id] = teams
+            metadata.fallback_teams.update(teams)
+
+    return metadata
+
+
+def _legacy_statistics(statistics: dict | None) -> dict:
+    statistics = statistics or {}
+    return {
+        "count_50": statistics.get("count_50", statistics.get("meh")),
+        "count_100": statistics.get("count_100", statistics.get("ok")),
+        "count_300": statistics.get("count_300", statistics.get("great")),
+        "count_geki": statistics.get("count_geki", statistics.get("perfect")),
+        "count_katu": statistics.get("count_katu", statistics.get("good")),
+        "count_miss": statistics.get("count_miss", statistics.get("miss")),
+    }
+
+
+def _room_score(score: dict, item: dict, team_map: dict[str, str], mode: str) -> dict:
+    team = team_map.get(str(score.get("user_id", "")), "none")
+    if team not in {"red", "blue"}:
+        team = "none"
+    return {
+        "user_id": score.get("user_id"),
+        "score": score.get("total_score", score.get("score", 0)),
+        "accuracy": score.get("accuracy", 0),
+        "max_combo": score.get("max_combo", 0),
+        "mods": normalize_mods(score.get("mods")),
+        "perfect": int(bool(score.get("is_perfect_combo", score.get("perfect", False)))),
+        "statistics": _legacy_statistics(score.get("statistics")),
+        "passed": bool(score.get("passed", True)),
+        "rank": score.get("rank") or "F",
+        "created_at": score.get("ended_at") or score.get("created_at") or item.get("played_at") or "",
+        "mode": mode,
+        "mode_int": FGM.get(mode, 0),
+        "match": {"team": team, "passed": bool(score.get("passed", True))},
+    }
+
+
+def _room_beatmap(item: dict) -> dict:
+    beatmap = item.get("beatmap") or {}
+    beatmapset = beatmap.get("beatmapset") or {}
+    covers = beatmapset.get("covers") or {}
+    cover = covers.get("cover", "")
+    return {
+        "id": beatmap.get("id"),
+        "mode": beatmap.get("mode", "osu"),
+        "status": beatmap.get("status", "ranked"),
+        "total_length": beatmap.get("total_length", 0),
+        "user_id": beatmap.get("user_id", 0),
+        "version": beatmap.get("version", ""),
+        "difficulty_rating": beatmap.get("difficulty_rating", 0),
+        "beatmapset_id": beatmap.get("beatmapset_id"),
+        "beatmapset": {
+            "id": beatmapset.get("id", beatmap.get("beatmapset_id", 0)),
+            "title": beatmapset.get("title", ""),
+            "title_unicode": beatmapset.get("title_unicode", beatmapset.get("title", "")),
+            "artist": beatmapset.get("artist", ""),
+            "artist_unicode": beatmapset.get("artist_unicode", beatmapset.get("artist", "")),
+            "creator": beatmapset.get("creator", ""),
+            "user_id": beatmapset.get("user_id", 0),
+            "source": beatmapset.get("source", ""),
+            "status": beatmapset.get("status", "ranked"),
+            "nsfw": beatmapset.get("nsfw", False),
+            "video": beatmapset.get("video", False),
+            "favourite_count": beatmapset.get("favourite_count", 0),
+            "play_count": beatmapset.get("play_count", 0),
+            "preview_url": beatmapset.get("preview_url", ""),
+            "covers": {
+                "cover": cover,
+                "card": covers.get("card", cover),
+                "list": covers.get("list", cover),
+                "slimcover": covers.get("slimcover", cover),
+            },
+        },
+    }
+
+
+async def convert_room_to_match(raw: dict, room_id: str) -> dict:
+    """Convert an osu!lazer room response into the legacy Match schema."""
+    metadata = await fetch_room_event_metadata(room_id)
+    users: dict[int, dict] = {}
+    for user in [raw.get("host"), *(raw.get("recent_participants") or [])]:
+        if isinstance(user, dict) and user.get("id"):
+            users[user["id"]] = user
+
+    events: list[dict] = []
+    fallback_room_type = raw.get("type", "head_to_head")
+    for item in raw.get("playlist") or []:
+        if not item.get("played_at"):
+            continue
+        try:
+            playlist_id = int(item["id"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if playlist_id in metadata.aborted_playlist_ids:
+            continue
+
+        try:
+            score_data = await api_info(
+                "matches", f"https://osu.ppy.sh/api/v2/rooms/{room_id}/playlist/{playlist_id}/scores"
+            )
+        except Exception as exc:
+            logger.debug(f"[room-scores] room {room_id}, playlist {playlist_id}: request failed ({exc})")
+            continue
+
+        scores = score_data.get("scores") if isinstance(score_data, dict) else None
+        if not scores:
+            continue
+        for score in scores:
+            user = score.get("user")
+            if isinstance(user, dict) and user.get("id"):
+                users.setdefault(user["id"], user)
+
+        raw_room_type = metadata.room_types_by_playlist.get(playlist_id, fallback_room_type)
+        room_type = _ROOM_TYPE_MAP.get(raw_room_type, raw_room_type)
+        teams = (
+            metadata.teams_by_playlist.get(playlist_id) or metadata.fallback_teams
+            if room_type in {"team-vs", "tag-team-vs"}
+            else {}
+        )
+        beatmap = _room_beatmap(item)
+        mode = beatmap["mode"]
+        game_scores = [_room_score(score, item, teams, mode) for score in scores]
+        events.append(
+            {
+                "id": playlist_id,
+                "detail": {"type": "other"},
+                "timestamp": item.get("played_at", ""),
+                "game": {
+                    "id": playlist_id,
+                    "beatmap_id": item.get("beatmap_id"),
+                    "team_type": room_type,
+                    "mods": normalize_mods(item.get("required_mods")),
+                    "beatmap": beatmap,
+                    "scores": game_scores,
+                },
+            }
+        )
+
+    return {
+        "match": {
+            "id": raw.get("id"),
+            "name": raw.get("name", ""),
+            "start_time": raw.get("starts_at") or raw.get("created_at", ""),
+            "end_time": raw.get("ends_at"),
+        },
+        "events": events,
+        "users": list(users.values()),
+    }

--- a/src/nonebot_plugin_osubot/matcher/match.py
+++ b/src/nonebot_plugin_osubot/matcher/match.py
@@ -41,7 +41,7 @@ async def _send_with_retry(coro_factory):
             raise
 
 
-def _build_nodes(self_id: int, images: list[bytes]) -> list[dict]:
+def _build_nodes(self_id: object, images: list[bytes]) -> list[dict]:
     """构造 OneBot v11 合并转发的标准 node 列表（原始 dict 形式，兼容性最好）。"""
     nodes = []
     for i, img in enumerate(images, start=1):
@@ -71,10 +71,8 @@ async def _send_forward(bot, event, images: list[bytes]) -> bool:
 
     group_id = getattr(event, "group_id", None)
     user_id = getattr(event, "user_id", None)
-    self_id = int(bot.self_id)
-
     try:
-        nodes = _build_nodes(self_id, images)
+        nodes = _build_nodes(bot.self_id, images)
     except Exception:
         return False
 

--- a/src/nonebot_plugin_osubot/matcher/match.py
+++ b/src/nonebot_plugin_osubot/matcher/match.py
@@ -24,18 +24,18 @@ from ..draw.match_history import draw_match_history
 
 match = on_command("match", aliases={"mp"}, priority=11, block=True)
 
-SEND_RETRY = 2
+SEND_RETRIES = 2
 SEND_RETRY_INTERVAL = 2
 USE_FORWARD = True  # 多图时用合并转发
 
 
 async def _send_with_retry(coro_factory):
     """对一个『返回 awaitable 的工厂』做重试，仅捕获 NetworkError。"""
-    for attempt in range(SEND_RETRY):
+    for attempt in range(SEND_RETRIES + 1):
         try:
             return await coro_factory()
         except NetworkError:
-            if attempt < SEND_RETRY - 1:
+            if attempt < SEND_RETRIES:
                 await asyncio.sleep(SEND_RETRY_INTERVAL)
                 continue
             raise

--- a/src/nonebot_plugin_osubot/matcher/match.py
+++ b/src/nonebot_plugin_osubot/matcher/match.py
@@ -11,12 +11,14 @@ try:
     from nonebot.adapters.onebot.v11.exception import NetworkError
     from nonebot.adapters.onebot.v11 import Message as OB11Message  # noqa: F401
     from nonebot.adapters.onebot.v11 import MessageSegment  # noqa: F401
+
     _OB11_OK = True
 except ImportError:
     _OB11_OK = False
 
     class NetworkError(Exception):
         pass
+
 
 from ..draw.match_history import draw_match_history
 
@@ -32,6 +34,7 @@ def is_primary_bot(self_id: object) -> bool:
     except Exception:
         return True
     return _primary.is_primary_bot(self_id)
+
 
 SEND_RETRY = 2
 SEND_RETRY_INTERVAL = 2
@@ -89,13 +92,9 @@ async def _send_forward(bot, event, images: list[bytes]) -> bool:
 
     try:
         if group_id is not None:
-            await _send_with_retry(
-                lambda: bot.call_api("send_group_forward_msg", group_id=group_id, messages=nodes)
-            )
+            await _send_with_retry(lambda: bot.call_api("send_group_forward_msg", group_id=group_id, messages=nodes))
         elif user_id is not None:
-            await _send_with_retry(
-                lambda: bot.call_api("send_private_forward_msg", user_id=user_id, messages=nodes)
-            )
+            await _send_with_retry(lambda: bot.call_api("send_private_forward_msg", user_id=user_id, messages=nodes))
         else:
             return False
         return True
@@ -106,9 +105,7 @@ async def _send_forward(bot, event, images: list[bytes]) -> bool:
 async def _send_one_by_one(images: list[bytes]):
     """退化方案：逐张发送。"""
     for index, img in enumerate(images):
-        await _send_with_retry(
-            lambda raw=img, first=(index == 0): UniMessage.image(raw=raw).send(reply_to=first)
-        )
+        await _send_with_retry(lambda raw=img, first=(index == 0): UniMessage.image(raw=raw).send(reply_to=first))
         if index < len(images) - 1:
             await asyncio.sleep(0.5)
 

--- a/src/nonebot_plugin_osubot/matcher/match.py
+++ b/src/nonebot_plugin_osubot/matcher/match.py
@@ -24,18 +24,6 @@ from ..draw.match_history import draw_match_history
 
 match = on_command("match", aliases={"mp"}, priority=11, block=True)
 
-
-def is_primary_bot(self_id: object) -> bool:
-    """判断当前 bot 是否为主号；主号去重插件未加载时一律视为主号（保持旧行为）。"""
-    try:
-        from nonebot import require
-
-        _primary = require("nonebot_plugin_primary_bot")
-    except Exception:
-        return True
-    return _primary.is_primary_bot(self_id)
-
-
 SEND_RETRY = 2
 SEND_RETRY_INTERVAL = 2
 USE_FORWARD = True  # 多图时用合并转发
@@ -124,11 +112,6 @@ async def _help(bot: Bot, arg: Message = CommandArg(), event: Event = None):
     # 单图：直接回复发送
     if len(pages) == 1:
         await _send_with_retry(lambda: UniMessage.image(raw=pages[0]).finish(reply_to=True))
-        return
-
-    # 多图：主号走合并转发；分身降级为逐张发送（多 bot 并存时避免发错账号）
-    if not is_primary_bot(bot.self_id):
-        await _send_one_by_one(pages)
         return
 
     # 多图：优先合并转发，失败则逐张发送

--- a/src/nonebot_plugin_osubot/matcher/match.py
+++ b/src/nonebot_plugin_osubot/matcher/match.py
@@ -1,15 +1,142 @@
+import asyncio
+import base64
+
 from nonebot import on_command
+from nonebot.log import logger
 from nonebot.params import CommandArg
-from nonebot.internal.adapter import Message
+from nonebot.internal.adapter import Bot, Message, Event
 from nonebot_plugin_alconna import UniMessage
+
+try:
+    from nonebot.adapters.onebot.v11.exception import NetworkError
+    from nonebot.adapters.onebot.v11 import Message as OB11Message  # noqa: F401
+    from nonebot.adapters.onebot.v11 import MessageSegment  # noqa: F401
+    _OB11_OK = True
+except ImportError:
+    _OB11_OK = False
+
+    class NetworkError(Exception):
+        pass
 
 from ..draw.match_history import draw_match_history
 
 match = on_command("match", aliases={"mp"}, priority=11, block=True)
 
 
+def is_primary_bot(self_id: object) -> bool:
+    """判断当前 bot 是否为主号；主号去重插件未加载时一律视为主号（保持旧行为）。"""
+    try:
+        from nonebot import require
+
+        _primary = require("nonebot_plugin_primary_bot")
+    except Exception:
+        return True
+    return _primary.is_primary_bot(self_id)
+
+SEND_RETRY = 2
+SEND_RETRY_INTERVAL = 2
+USE_FORWARD = True  # 多图时用合并转发
+
+
+async def _send_with_retry(coro_factory):
+    """对一个『返回 awaitable 的工厂』做重试，仅捕获 NetworkError。"""
+    for attempt in range(SEND_RETRY):
+        try:
+            return await coro_factory()
+        except NetworkError:
+            if attempt < SEND_RETRY - 1:
+                await asyncio.sleep(SEND_RETRY_INTERVAL)
+                continue
+            raise
+
+
+def _build_nodes(self_id: int, images: list[bytes]) -> list[dict]:
+    """构造 OneBot v11 合并转发的标准 node 列表（原始 dict 形式，兼容性最好）。"""
+    nodes = []
+    for i, img in enumerate(images, start=1):
+        b64 = base64.b64encode(img).decode()
+        nodes.append(
+            {
+                "type": "node",
+                "data": {
+                    "user_id": str(self_id),
+                    "nickname": f"osu! 多人房战报 ({i}/{len(images)})",
+                    "content": [
+                        {
+                            "type": "image",
+                            "data": {"file": f"base64://{b64}"},
+                        }
+                    ],
+                },
+            }
+        )
+    return nodes
+
+
+async def _send_forward(bot, event, images: list[bytes]) -> bool:
+    """尝试合并转发发送，成功返回 True，环境不支持返回 False。"""
+    if not _OB11_OK:
+        return False
+
+    group_id = getattr(event, "group_id", None)
+    user_id = getattr(event, "user_id", None)
+    self_id = int(bot.self_id)
+
+    try:
+        nodes = _build_nodes(self_id, images)
+    except Exception:
+        return False
+
+    try:
+        if group_id is not None:
+            await _send_with_retry(
+                lambda: bot.call_api("send_group_forward_msg", group_id=group_id, messages=nodes)
+            )
+        elif user_id is not None:
+            await _send_with_retry(
+                lambda: bot.call_api("send_private_forward_msg", user_id=user_id, messages=nodes)
+            )
+        else:
+            return False
+        return True
+    except Exception:
+        return False
+
+
+async def _send_one_by_one(images: list[bytes]):
+    """退化方案：逐张发送。"""
+    for index, img in enumerate(images):
+        await _send_with_retry(
+            lambda raw=img, first=(index == 0): UniMessage.image(raw=raw).send(reply_to=first)
+        )
+        if index < len(images) - 1:
+            await asyncio.sleep(0.5)
+
+
 @match.handle()
-async def _help(arg: Message = CommandArg()):
+async def _help(bot: Bot, arg: Message = CommandArg(), event: Event = None):
     arg = arg.extract_plain_text().strip()
-    img = await draw_match_history(arg)
-    await UniMessage.image(raw=img).finish(reply_to=True)
+    if not arg or not arg.isdigit():
+        await match.finish("请输入比赛/多人房 ID，例如：/mp 3985712")
+    try:
+        pages = await draw_match_history(arg)
+    except Exception as e:
+        logger.opt(exception=e).error(f"绘制 match 历史失败: match_id={arg}")
+        await match.finish(f"查询失败，请稍后再试或联系管理员\n错误信息: {e}")
+
+    # 单图：直接回复发送
+    if len(pages) == 1:
+        await _send_with_retry(lambda: UniMessage.image(raw=pages[0]).finish(reply_to=True))
+        return
+
+    # 多图：主号走合并转发；分身降级为逐张发送（多 bot 并存时避免发错账号）
+    if not is_primary_bot(bot.self_id):
+        await _send_one_by_one(pages)
+        return
+
+    # 多图：优先合并转发，失败则逐张发送
+    if USE_FORWARD:
+        if await _send_forward(bot, event, pages):
+            return
+
+    await _send_one_by_one(pages)

--- a/src/nonebot_plugin_osubot/schema/match.py
+++ b/src/nonebot_plugin_osubot/schema/match.py
@@ -1,6 +1,19 @@
-from typing import Optional, List, Union
+from typing import Optional
 
-from pydantic import field_validator
+from pydantic import Field
+
+try:
+    from pydantic import field_validator
+
+    def _before_validator(field: str):
+        return field_validator(field, mode="before")
+
+except ImportError:  # Pydantic v1
+    from pydantic import validator
+
+    def _before_validator(field: str):
+        return validator(field, pre=True, allow_reuse=True)
+
 
 from .user import User
 from .score import Score
@@ -8,31 +21,37 @@ from .basemodel import Base
 from .beatmap import BeatmapCompact
 
 
+def normalize_mods(value) -> list[str]:
+    """Normalize legacy strings and lazer mod objects to acronym strings."""
+    if not value:
+        return []
+
+    result: list[str] = []
+    for mod in value:
+        acronym = (
+            mod.get("acronym")
+            if isinstance(mod, dict)
+            else mod
+            if isinstance(mod, str)
+            else getattr(mod, "acronym", None)
+        )
+        if acronym:
+            result.append(str(acronym))
+    return result
+
+
 class Game(Base):
     beatmap_id: int
-    # 【修改点 1】mods 兼容 str 和 dict/Mod 对象
-    mods: List[Union[str, dict]] = []
+    mods: list[str] = Field(default_factory=list)
 
     beatmap: BeatmapCompact
     scores: list[Score]
     team_type: str
 
-    # 【新增验证器】统一处理 game 级别的 mods
-    @field_validator("mods", mode="before")
+    @_before_validator("mods")
     @classmethod
     def parse_mods(cls, v):
-        if not v:
-            return []
-
-        result = []
-        for m in v:
-            if isinstance(m, dict):
-                result.append(m.get("acronym", ""))
-            elif isinstance(m, str):
-                result.append(m)
-            else:
-                result.append(getattr(m, "acronym", str(m)))
-        return result
+        return normalize_mods(v)
 
 
 class Detail(Base):

--- a/src/nonebot_plugin_osubot/schema/match.py
+++ b/src/nonebot_plugin_osubot/schema/match.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from typing import Optional, List, Union
+
+from pydantic import field_validator
 
 from .user import User
 from .score import Score
@@ -8,10 +10,29 @@ from .beatmap import BeatmapCompact
 
 class Game(Base):
     beatmap_id: int
-    mods: list[str]
+    # 【修改点 1】mods 兼容 str 和 dict/Mod 对象
+    mods: List[Union[str, dict]] = []
+    
     beatmap: BeatmapCompact
     scores: list[Score]
     team_type: str
+
+    # 【新增验证器】统一处理 game 级别的 mods
+    @field_validator('mods', mode='before')
+    @classmethod
+    def parse_mods(cls, v):
+        if not v:
+            return []
+        
+        result = []
+        for m in v:
+            if isinstance(m, dict):
+                result.append(m.get('acronym', ''))
+            elif isinstance(m, str):
+                result.append(m)
+            else:
+                result.append(getattr(m, 'acronym', str(m)))
+        return result
 
 
 class Detail(Base):

--- a/src/nonebot_plugin_osubot/schema/match.py
+++ b/src/nonebot_plugin_osubot/schema/match.py
@@ -12,26 +12,26 @@ class Game(Base):
     beatmap_id: int
     # 【修改点 1】mods 兼容 str 和 dict/Mod 对象
     mods: List[Union[str, dict]] = []
-    
+
     beatmap: BeatmapCompact
     scores: list[Score]
     team_type: str
 
     # 【新增验证器】统一处理 game 级别的 mods
-    @field_validator('mods', mode='before')
+    @field_validator("mods", mode="before")
     @classmethod
     def parse_mods(cls, v):
         if not v:
             return []
-        
+
         result = []
         for m in v:
             if isinstance(m, dict):
-                result.append(m.get('acronym', ''))
+                result.append(m.get("acronym", ""))
             elif isinstance(m, str):
                 result.append(m)
             else:
-                result.append(getattr(m, 'acronym', str(m)))
+                result.append(getattr(m, "acronym", str(m)))
         return result
 
 

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -1,0 +1,182 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _user(user_id: int, name: str) -> dict:
+    return {
+        "id": user_id,
+        "username": name,
+        "avatar_url": f"https://example.com/{user_id}.png",
+        "country_code": "CN",
+        "default_group": "default",
+        "is_active": True,
+        "is_bot": False,
+        "is_deleted": False,
+        "is_online": False,
+        "is_supporter": False,
+    }
+
+
+def _beatmap() -> dict:
+    cover = "https://example.com/cover.jpg"
+    return {
+        "id": 11,
+        "beatmapset_id": 22,
+        "difficulty_rating": 5.0,
+        "mode": "osu",
+        "status": "ranked",
+        "total_length": 120,
+        "user_id": 1,
+        "version": "Insane",
+        "beatmapset": {
+            "id": 22,
+            "artist": "Artist",
+            "artist_unicode": "Artist",
+            "covers": {"cover": cover, "card": cover, "list": cover, "slimcover": cover},
+            "creator": "Mapper",
+            "favourite_count": 0,
+            "nsfw": False,
+            "play_count": 0,
+            "preview_url": "",
+            "source": "",
+            "status": "ranked",
+            "title": "Song",
+            "title_unicode": "Song",
+            "user_id": 1,
+            "video": False,
+        },
+    }
+
+
+def _score(user_id: int, score: int, team: str, *, passed: bool) -> dict:
+    return {
+        "user_id": user_id,
+        "accuracy": 0.98,
+        "mods": [],
+        "score": score,
+        "max_combo": 100,
+        "perfect": 0,
+        "statistics": {},
+        "passed": passed,
+        "rank": "A" if passed else "F",
+        "created_at": "2026-08-24T00:00:00Z",
+        "mode": "osu",
+        "mode_int": 0,
+        "match": {"team": team, "passed": passed},
+    }
+
+
+def _traditional_match() -> dict:
+    return {
+        "match": {
+            "id": 1,
+            "name": "Lobby",
+            "start_time": "2026-08-24T00:00:00+00:00",
+            "end_time": "2026-08-24T01:00:00+00:00",
+        },
+        "events": [
+            {
+                "id": 1,
+                "detail": {"type": "other"},
+                "timestamp": "2026-08-24T01:00:00Z",
+                "game": {
+                    "beatmap_id": 11,
+                    "mods": [],
+                    "beatmap": _beatmap(),
+                    "team_type": "team-vs",
+                    "scores": [
+                        _score(1, 100, "red", passed=False),
+                        _score(2, 0, "red", passed=False),
+                        _score(3, 90, "blue", passed=True),
+                    ],
+                },
+            }
+        ],
+        "users": [_user(1, "red"), _user(2, "zero"), _user(3, "blue")],
+    }
+
+
+def test_traditional_match_preserves_score_filter_and_winner(after_nonebot_init):
+    from nonebot_plugin_osubot.draw.match_history import prepare_match_data
+    from nonebot_plugin_osubot.schema.match import Match
+
+    data = prepare_match_data(Match(**_traditional_match()), "1", team_type_filter="team-vs")
+
+    assert [player["name"] for player in data["games"][0]["players"]] == ["red", "blue"]
+    assert data["games"][0]["red_score"] == 100
+    assert data["games"][0]["winner"] == "red"
+
+
+@pytest.mark.asyncio
+async def test_lazer_room_conversion_satisfies_match_schema(after_nonebot_init, monkeypatch):
+    from nonebot_plugin_osubot import match_room
+    from nonebot_plugin_osubot.schema.match import Match
+
+    metadata = match_room.RoomEventMetadata(
+        teams_by_playlist={7: {"1": "red"}},
+        room_types_by_playlist={7: "team_versus"},
+    )
+    monkeypatch.setattr(match_room, "fetch_room_event_metadata", AsyncMock(return_value=metadata))
+    monkeypatch.setattr(
+        match_room,
+        "api_info",
+        AsyncMock(
+            return_value={
+                "scores": [
+                    {
+                        "user_id": 1,
+                        "total_score": 123,
+                        "accuracy": 0.99,
+                        "max_combo": 50,
+                        "mods": [{"acronym": "HD"}],
+                        "statistics": {"great": 10, "miss": 1},
+                        "passed": True,
+                        "rank": "A",
+                        "ended_at": "2026-08-24T01:00:00Z",
+                        "user": _user(1, "player"),
+                    }
+                ]
+            }
+        ),
+    )
+    raw = {
+        "id": 9,
+        "name": "Lazer room",
+        "type": "head_to_head",
+        "starts_at": "2026-08-24T00:00:00+00:00",
+        "ends_at": "2026-08-24T01:00:00+00:00",
+        "host": _user(1, "player"),
+        "playlist": [
+            {
+                "id": 7,
+                "played_at": "2026-08-24T01:00:00Z",
+                "beatmap_id": 11,
+                "required_mods": [{"acronym": "HR"}],
+                "beatmap": _beatmap(),
+            }
+        ],
+    }
+
+    converted = await match_room.convert_room_to_match(raw, "9")
+    match = Match(**converted)
+
+    score = match.events[0].game.scores[0]
+    assert score.mods == ["HD"]
+    assert score.statistics.count_300 == 10
+    assert score.match == {"team": "red", "passed": True}
+
+
+@pytest.mark.asyncio
+async def test_draw_match_history_keeps_return_data_contract(after_nonebot_init, monkeypatch):
+    from nonebot_plugin_osubot.draw import match_history
+
+    monkeypatch.setattr(match_history, "api_info", AsyncMock(return_value=_traditional_match()))
+    monkeypatch.setattr(match_history, "draw_match_card", AsyncMock(return_value=b"image"))
+    monkeypatch.setattr(match_history, "compress_jpeg", lambda image: image)
+
+    image, data = await match_history.draw_match_history("1", query_type="match", return_data=True)
+
+    assert image == b"image"
+    assert data["match_id"] == "1"
+    assert data["games"][0]["winner"] == "red"

--- a/tests/test_match_history.py
+++ b/tests/test_match_history.py
@@ -168,15 +168,52 @@ async def test_lazer_room_conversion_satisfies_match_schema(after_nonebot_init, 
 
 
 @pytest.mark.asyncio
+async def test_fetch_room_event_metadata_parses_events(after_nonebot_init, monkeypatch):
+    from nonebot_plugin_osubot import match_room
+
+    monkeypatch.setattr(
+        match_room,
+        "api_info",
+        AsyncMock(
+            return_value={
+                "events": [
+                    {"event_type": "game_aborted", "playlist_item_id": "8"},
+                    {"event_type": "game_aborted", "playlist_item_id": None},
+                ],
+                "playlist": [
+                    {
+                        "id": "7",
+                        "details": {
+                            "room_type": "team_versus",
+                            "teams": {"1": "red", "2": "blue", "3": "invalid"},
+                        },
+                    }
+                ],
+            }
+        ),
+    )
+
+    metadata = await match_room.fetch_room_event_metadata("42")
+
+    assert metadata.aborted_playlist_ids == {8}
+    assert metadata.room_types_by_playlist == {7: "team_versus"}
+    assert metadata.teams_by_playlist == {7: {"1": "red", "2": "blue"}}
+    assert metadata.fallback_teams == {"1": "red", "2": "blue"}
+
+
+@pytest.mark.asyncio
 async def test_draw_match_history_keeps_return_data_contract(after_nonebot_init, monkeypatch):
     from nonebot_plugin_osubot.draw import match_history
 
     monkeypatch.setattr(match_history, "api_info", AsyncMock(return_value=_traditional_match()))
-    monkeypatch.setattr(match_history, "draw_match_card", AsyncMock(return_value=b"image"))
+    draw_card = AsyncMock(return_value=b"image")
+    monkeypatch.setattr(match_history, "draw_match_card", draw_card)
     monkeypatch.setattr(match_history, "compress_jpeg", lambda image: image)
+    monkeypatch.setattr(match_history, "_chunk_games", lambda games: [games, games])
 
     image, data = await match_history.draw_match_history("1", query_type="match", return_data=True)
 
     assert image == b"image"
     assert data["match_id"] == "1"
     assert data["games"][0]["winner"] == "red"
+    draw_card.assert_awaited_once()

--- a/tests/test_match_schema.py
+++ b/tests/test_match_schema.py
@@ -1,0 +1,7 @@
+from types import SimpleNamespace
+
+
+def test_game_mods_accept_strings_dicts_and_objects(after_nonebot_init):
+    from nonebot_plugin_osubot.schema.match import Game
+
+    assert Game.parse_mods(["HD", {"acronym": "DT"}, SimpleNamespace(acronym="HR")]) == ["HD", "DT", "HR"]

--- a/tests/test_simple_matchers.py
+++ b/tests/test_simple_matchers.py
@@ -506,6 +506,21 @@ async def test_match_send_retries_network_error_twice(app: App):
     assert sleep.await_count == 2
 
 
+@pytest.mark.asyncio
+async def test_match_forward_accepts_non_numeric_self_id(app: App):
+    match_module = importlib.import_module(MATCH_MODULE)
+    bot = MagicMock(self_id="bot-alpha")
+    bot.call_api = AsyncMock(return_value={"message_id": 1})
+    event = MagicMock(group_id=123, user_id=456)
+
+    with patch(f"{MATCH_MODULE}._OB11_OK", True):
+        sent = await match_module._send_forward(bot, event, [b"PAGE"])
+
+    assert sent is True
+    messages = bot.call_api.await_args.kwargs["messages"]
+    assert messages[0]["data"]["user_id"] == "bot-alpha"
+
+
 # ---------------------------------------------------------------------------
 # /rating
 # ---------------------------------------------------------------------------

--- a/tests/test_simple_matchers.py
+++ b/tests/test_simple_matchers.py
@@ -445,7 +445,7 @@ async def test_match_success(app: App):
 
     event = fake_group_message_event_v11(message=Message("/match 114514"))
 
-    with patch(f"{MATCH_MODULE}.draw_match_history", new=AsyncMock(return_value=FAKE_IMG)):
+    with patch(f"{MATCH_MODULE}.draw_match_history", new=AsyncMock(return_value=[FAKE_IMG])):
         async with app.test_matcher(match) as ctx:
             adapter = nonebot.get_adapter(OnebotV11Adapter)
             bot = ctx.create_bot(base=Bot, adapter=adapter)
@@ -461,6 +461,34 @@ async def test_match_success(app: App):
                 result={"message_id": 1},
             )
             ctx.should_finished()
+
+
+@pytest.mark.asyncio
+async def test_match_multiple_images_always_tries_forward(app: App):
+    """多图发送不在 osubot 内部判断主号或分身。"""
+    try:
+        from nonebot_plugin_osubot.matcher.match import match
+    except ImportError:
+        pytest.skip()
+    import nonebot
+
+    pages = [b"PAGE_1", b"PAGE_2"]
+    event = fake_group_message_event_v11(message=Message("/match 114514"))
+    forward = AsyncMock(return_value=True)
+    one_by_one = AsyncMock()
+
+    with (
+        patch(f"{MATCH_MODULE}.draw_match_history", new=AsyncMock(return_value=pages)),
+        patch(f"{MATCH_MODULE}._send_forward", new=forward),
+        patch(f"{MATCH_MODULE}._send_one_by_one", new=one_by_one),
+    ):
+        async with app.test_matcher(match) as ctx:
+            adapter = nonebot.get_adapter(OnebotV11Adapter)
+            bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="1919810")
+            ctx.receive_event(bot, event)
+
+    forward.assert_awaited_once_with(bot, event, pages)
+    one_by_one.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_simple_matchers.py
+++ b/tests/test_simple_matchers.py
@@ -1,5 +1,7 @@
 """简单 matcher 测试：mu / osu_help / history / url_match / match / rating"""
 
+import importlib
+
 import pytest
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from nonebot.adapters.onebot.v11 import Adapter as OnebotV11Adapter, Bot, Message, MessageSegment
@@ -489,6 +491,19 @@ async def test_match_multiple_images_always_tries_forward(app: App):
 
     forward.assert_awaited_once_with(bot, event, pages)
     one_by_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_match_send_retries_network_error_twice(app: App):
+    match_module = importlib.import_module(MATCH_MODULE)
+
+    operation = AsyncMock(side_effect=[match_module.NetworkError("first"), match_module.NetworkError("second"), "sent"])
+    with patch(f"{MATCH_MODULE}.asyncio.sleep", new=AsyncMock()) as sleep:
+        result = await match_module._send_with_retry(operation)
+
+    assert result == "sent"
+    assert operation.await_count == 3
+    assert sleep.await_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景
`/mp` 目前只输出一张合并长图：多局比赛（如 8~16 局）时图片过长、手机端看不清，且长图渲染失败率随局数上升。

## 改动
- `draw/match_history.py`：
  - 按局分页渲染（每页最多 32 行，可调），长图变多张清晰小图；
  - 使用项目现有 Pillow 依赖输出 JPEG 压缩；
  - 支持 osu!lazer 多人房 `/rooms/{id}`：自动识别并转换为 matches 格式，兼容 lazer 房间的 mods 对象格式与 team_type 取值；
  - 新增 `query_type` 参数：`match`（仅传统房间）/ `room`（仅 lazer 房间）/ `auto`（先 matches 后 rooms，默认）；
  - 房间中途切换模式时按模式分组分别出图。
- `matcher/match.py`：
  - 单图：直接回复（带重试）；
  - 多图：优先合并转发（`send_group_forward_msg` / `send_private_forward_msg`），失败或非 OneBot 环境自动降级为逐张发送；
  - 发送遇到 `NetworkError` 时重试 2 次、间隔 2 秒。
- `schema/match.py`：`Game.mods` 兼容 str 与 dict/Mod 对象（lazer 房间返回对象格式）。

## 兼容性
- 不破坏现有 `/mp` 指令、单图行为及 `draw_match_history(return_data=True)` 调用；
- 非 OneBot 适配器自动走逐张发送；
- 兼容 Pydantic v1 与 v2。

## 测试
- 已添加传统单局兼容、分页发送、lazer 数据转换、mods 兼容和发送重试测试。
- 本地完整测试：320 passed，36 skipped。
