### PR TITLE
feat(audio): 新增 /au 谱面试听指令

### DIFF
--- a/src/nonebot_plugin_osubot/api.py
+++ b/src/nonebot_plugin_osubot/api.py
@@ -517,6 +517,7 @@ async def get_preview_audio(sid: int) -> bytes | None:
         return res.content
     return None
 
+
 async def get_users(users: list[int]):
     headers = await get_headers()
     req = await safe_async_get(f"{api}/users", headers=headers, params={"ids[]": users})

--- a/src/nonebot_plugin_osubot/api.py
+++ b/src/nonebot_plugin_osubot/api.py
@@ -497,25 +497,27 @@ async def get_user_info(url: str) -> dict:
     return await make_request(url, await get_headers(), "未找到该玩家，请确认玩家ID是否正确")
 
 
-async def get_preview_audio(sid: int) -> bytes | None:
-    """
-    获取谱面集(sid)的官方 30s 试听音频，返回 mp3 字节流。
-    接口文档(SayoBot 静态资源 - 试听音频):
-        https://cdn.sayobot.cn:25225/preview/{sid}.mp3
-        https://a.sayobot.cn/preview/{sid}.mp3
-    获取失败或内容不合法时返回 None。
-    """
-    res = await get_first_response(
-        [
-            f"https://cdn.sayobot.cn:25225/preview/{sid}.mp3",
-            f"https://a.sayobot.cn/preview/{sid}.mp3",
-        ],
-        timeout=15.0,
-    )
+async def _get_preview_audio(urls: list[str]) -> bytes | None:
+    res = await get_first_response(urls, timeout=15.0)
     # 校验：必须 200 且内容足够大（排除错误页/空文件）
     if res and res.status_code == 200 and len(res.content) > 1024:
         return res.content
     return None
+
+
+async def get_preview_audio(bid: int) -> bytes | None:
+    """获取指定谱面(bid)的试听音频。"""
+    return await _get_preview_audio([f"https://osu.direct/api/media/preview/{bid}"])
+
+
+async def get_beatmapset_preview_audio(sid: int) -> bytes | None:
+    """在只有谱面集 ID 时，获取该谱面集的默认试听音频。"""
+    return await _get_preview_audio(
+        [
+            f"https://cdn.sayobot.cn:25225/preview/{sid}.mp3",
+            f"https://a.sayobot.cn/preview/{sid}.mp3",
+        ]
+    )
 
 
 async def get_users(users: list[int]):

--- a/src/nonebot_plugin_osubot/api.py
+++ b/src/nonebot_plugin_osubot/api.py
@@ -497,6 +497,26 @@ async def get_user_info(url: str) -> dict:
     return await make_request(url, await get_headers(), "未找到该玩家，请确认玩家ID是否正确")
 
 
+async def get_preview_audio(sid: int) -> bytes | None:
+    """
+    获取谱面集(sid)的官方 30s 试听音频，返回 mp3 字节流。
+    接口文档(SayoBot 静态资源 - 试听音频):
+        https://cdn.sayobot.cn:25225/preview/{sid}.mp3
+        https://a.sayobot.cn/preview/{sid}.mp3
+    获取失败或内容不合法时返回 None。
+    """
+    res = await get_first_response(
+        [
+            f"https://cdn.sayobot.cn:25225/preview/{sid}.mp3",
+            f"https://a.sayobot.cn/preview/{sid}.mp3",
+        ],
+        timeout=15.0,
+    )
+    # 校验：必须 200 且内容足够大（排除错误页/空文件）
+    if res and res.status_code == 200 and len(res.content) > 1024:
+        return res.content
+    return None
+
 async def get_users(users: list[int]):
     headers = await get_headers()
     req = await safe_async_get(f"{api}/users", headers=headers, params={"ids[]": users})

--- a/src/nonebot_plugin_osubot/matcher/__init__.py
+++ b/src/nonebot_plugin_osubot/matcher/__init__.py
@@ -13,6 +13,7 @@ from .history import history
 from .bind import bind, unbind
 from .map import bmap, osu_map
 from .osu_help import osu_help
+from .audio import audio_preview
 from .rank import group_pp_rank
 from .recommend import recommend
 from .url_match import url_match
@@ -37,6 +38,7 @@ __all__ = [
     "recent",
     "recent_list",
     "osu_help",
+    "audio_preview",
     "url_match",
     "recommend",
     "update_info",

--- a/src/nonebot_plugin_osubot/matcher/audio.py
+++ b/src/nonebot_plugin_osubot/matcher/audio.py
@@ -1,0 +1,80 @@
+from nonebot import on_command
+from nonebot.typing import T_State
+from nonebot.internal.adapter import Event
+from nonebot_plugin_alconna import UniMessage
+
+from .utils import split_msg
+from .map_context import get_last_map_id, get_last_set_id
+from ..api import get_preview_audio, osu_api
+from ..exceptions import NetworkError
+
+audio_preview = on_command("au", priority=11, block=True)
+
+
+async def _bid_to_sid(bid: int) -> int | None:
+    """将谱面 ID(bid) 转换为谱面集 ID(sid)，失败返回 None。"""
+    try:
+        data = await osu_api("map", map_id=bid)
+    except NetworkError:
+        return None
+    sid = data.get("beatmapset_id")
+    return int(sid) if sid else None
+
+
+async def _fetch_voice(raw_id: int) -> bytes | None:
+    """
+    与 Kotlin 版 AudioService 的 fallback 逻辑保持一致：
+    先视 raw_id 为 bid，转换为 sid 后拉取音频；
+    若转换失败或音频拉取失败，再直接视 raw_id 为 sid 拉取。
+    """
+    sid = await _bid_to_sid(raw_id)
+    if sid is not None:
+        voice = await get_preview_audio(sid)
+        if voice:
+            return voice
+    return await get_preview_audio(raw_id)
+
+
+@audio_preview.handle(parameterless=[split_msg()])
+async def _audio(event: Event, state: T_State):
+    raw = state.get("target")
+    try:
+        explicit_id = int(raw) if raw else None
+    except (TypeError, ValueError):
+        await UniMessage.text("无效的地图ID，请输入数字ID").finish(reply_to=True)
+        return
+
+    voice: bytes | None = None
+    try:
+        if explicit_id:
+            voice = await _fetch_voice(explicit_id)
+        else:
+            # 未带 ID 时复用上下文：优先上一次 map 的 bid，其次上一次 bmap 的 sid
+            last_map = get_last_map_id(event)
+            if last_map:
+                voice = await _fetch_voice(last_map)
+            if not voice:
+                last_set = await get_last_set_id(event)
+                if last_set:
+                    voice = await get_preview_audio(last_set)
+    except NetworkError as e:
+        await UniMessage.text(f"谱面试听失败：{str(e)}").finish(reply_to=True)
+        return
+
+    if not voice:
+        await UniMessage.text(
+            "无法获取该谱面的音频，请检查ID是否正确，或先查询一张谱面后再试听"
+        ).finish(reply_to=True)
+        return
+
+    if not voice:
+        await UniMessage.text(
+            "无法获取该谱面的音频，请检查ID是否正确，或先查询一张谱面后再试听"
+        ).finish(reply_to=True)
+        return
+
+    # ① 先发一条带引用的提示（保留 reply_to，让用户知道在回复谁）
+    await UniMessage.text("🎵 谱面试听").send(reply_to=True)
+
+    # ② 再单独发语音 —— 关键：这里不要 reply_to，避免 reply+record 同条触发渲染 bug
+    await UniMessage.voice(raw=voice).finish()

--- a/src/nonebot_plugin_osubot/matcher/audio.py
+++ b/src/nonebot_plugin_osubot/matcher/audio.py
@@ -24,11 +24,15 @@ async def _bid_to_sid(bid: int) -> int | None:
 async def _fetch_voice(raw_id: int) -> bytes | None:
     """
     优先将 raw_id 视为 bid，按具体谱面拉取音频；
-    仅在它不是有效 bid 时，才将其视为 sid 拉取谱面集默认音频。
+    若该 bid 的音频不可用，则退回到其谱面集默认音频；
+    仅在它不是有效 bid 时，才直接将其视为 sid 拉取谱面集默认音频。
     """
     sid = await _bid_to_sid(raw_id)
     if sid is not None:
-        return await get_preview_audio(raw_id)
+        voice = await get_preview_audio(raw_id)
+        if voice:
+            return voice
+        return await get_beatmapset_preview_audio(sid)
     return await get_beatmapset_preview_audio(raw_id)
 
 

--- a/src/nonebot_plugin_osubot/matcher/audio.py
+++ b/src/nonebot_plugin_osubot/matcher/audio.py
@@ -62,15 +62,11 @@ async def _audio(event: Event, state: T_State):
         return
 
     if not voice:
-        await UniMessage.text(
-            "无法获取该谱面的音频，请检查ID是否正确，或先查询一张谱面后再试听"
-        ).finish(reply_to=True)
+        await UniMessage.text("无法获取该谱面的音频，请检查ID是否正确，或先查询一张谱面后再试听").finish(reply_to=True)
         return
 
     if not voice:
-        await UniMessage.text(
-            "无法获取该谱面的音频，请检查ID是否正确，或先查询一张谱面后再试听"
-        ).finish(reply_to=True)
+        await UniMessage.text("无法获取该谱面的音频，请检查ID是否正确，或先查询一张谱面后再试听").finish(reply_to=True)
         return
 
     # ① 先发一条带引用的提示（保留 reply_to，让用户知道在回复谁）

--- a/src/nonebot_plugin_osubot/matcher/audio.py
+++ b/src/nonebot_plugin_osubot/matcher/audio.py
@@ -5,7 +5,7 @@ from nonebot_plugin_alconna import UniMessage
 
 from .utils import split_msg
 from .map_context import get_last_map_id, get_last_set_id
-from ..api import get_preview_audio, osu_api
+from ..api import get_beatmapset_preview_audio, get_preview_audio, osu_api
 from ..exceptions import NetworkError
 
 audio_preview = on_command("au", priority=11, block=True)
@@ -23,16 +23,13 @@ async def _bid_to_sid(bid: int) -> int | None:
 
 async def _fetch_voice(raw_id: int) -> bytes | None:
     """
-    与 Kotlin 版 AudioService 的 fallback 逻辑保持一致：
-    先视 raw_id 为 bid，转换为 sid 后拉取音频；
-    若转换失败或音频拉取失败，再直接视 raw_id 为 sid 拉取。
+    优先将 raw_id 视为 bid，按具体谱面拉取音频；
+    仅在它不是有效 bid 时，才将其视为 sid 拉取谱面集默认音频。
     """
     sid = await _bid_to_sid(raw_id)
     if sid is not None:
-        voice = await get_preview_audio(sid)
-        if voice:
-            return voice
-    return await get_preview_audio(raw_id)
+        return await get_preview_audio(raw_id)
+    return await get_beatmapset_preview_audio(raw_id)
 
 
 @audio_preview.handle(parameterless=[split_msg()])
@@ -56,7 +53,7 @@ async def _audio(event: Event, state: T_State):
             if not voice:
                 last_set = await get_last_set_id(event)
                 if last_set:
-                    voice = await get_preview_audio(last_set)
+                    voice = await get_beatmapset_preview_audio(last_set)
     except NetworkError as e:
         await UniMessage.text(f"谱面试听失败：{str(e)}").finish(reply_to=True)
         return
@@ -65,12 +62,4 @@ async def _audio(event: Event, state: T_State):
         await UniMessage.text("无法获取该谱面的音频，请检查ID是否正确，或先查询一张谱面后再试听").finish(reply_to=True)
         return
 
-    if not voice:
-        await UniMessage.text("无法获取该谱面的音频，请检查ID是否正确，或先查询一张谱面后再试听").finish(reply_to=True)
-        return
-
-    # ① 先发一条带引用的提示（保留 reply_to，让用户知道在回复谁）
-    await UniMessage.text("🎵 谱面试听").send(reply_to=True)
-
-    # ② 再单独发语音 —— 关键：这里不要 reply_to，避免 reply+record 同条触发渲染 bug
     await UniMessage.voice(raw=voice).finish()

--- a/tests/test_audio_preview.py
+++ b/tests/test_audio_preview.py
@@ -1,0 +1,87 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def api_module(after_nonebot_init):
+    return importlib.import_module("nonebot_plugin_osubot.api")
+
+
+@pytest.fixture
+def audio_module(after_nonebot_init):
+    return importlib.import_module("nonebot_plugin_osubot.matcher.audio")
+
+
+@pytest.mark.asyncio
+async def test_preview_audio_uses_map_specific_osu_direct_endpoint(api_module):
+    response = SimpleNamespace(status_code=200, content=b"audio" * 1024)
+
+    with patch.object(api_module, "get_first_response", new=AsyncMock(return_value=response)) as request:
+        assert await api_module.get_preview_audio(123) == response.content
+
+    request.assert_awaited_once_with(
+        ["https://osu.direct/api/media/preview/123"],
+        timeout=15.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_beatmapset_preview_uses_only_set_id_mirrors(api_module):
+    response = SimpleNamespace(status_code=200, content=b"audio" * 1024)
+
+    with patch.object(api_module, "get_first_response", new=AsyncMock(return_value=response)) as request:
+        assert await api_module.get_beatmapset_preview_audio(456) == response.content
+
+    request.assert_awaited_once_with(
+        [
+            "https://cdn.sayobot.cn:25225/preview/456.mp3",
+            "https://a.sayobot.cn/preview/456.mp3",
+        ],
+        timeout=15.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_voice_uses_bid_specific_preview(audio_module):
+    with (
+        patch.object(audio_module, "_bid_to_sid", new=AsyncMock(return_value=456)),
+        patch.object(audio_module, "get_preview_audio", new=AsyncMock(return_value=b"audio")) as preview,
+        patch.object(audio_module, "get_beatmapset_preview_audio", new=AsyncMock()) as set_preview,
+    ):
+        assert await audio_module._fetch_voice(123) == b"audio"
+
+    preview.assert_awaited_once_with(123)
+    set_preview.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_voice_uses_set_preview_only_when_id_is_not_a_bid(audio_module):
+    with (
+        patch.object(audio_module, "_bid_to_sid", new=AsyncMock(return_value=None)),
+        patch.object(audio_module, "get_preview_audio", new=AsyncMock()) as preview,
+        patch.object(audio_module, "get_beatmapset_preview_audio", new=AsyncMock(return_value=b"audio")) as set_preview,
+    ):
+        assert await audio_module._fetch_voice(456) == b"audio"
+
+    preview.assert_not_awaited()
+    set_preview.assert_awaited_once_with(456)
+
+
+@pytest.mark.asyncio
+async def test_audio_command_sends_only_the_voice(audio_module):
+    message = MagicMock()
+    message.finish = AsyncMock()
+
+    with (
+        patch.object(audio_module, "_fetch_voice", new=AsyncMock(return_value=b"audio")),
+        patch.object(audio_module.UniMessage, "text") as text,
+        patch.object(audio_module.UniMessage, "voice", return_value=message) as voice,
+    ):
+        await audio_module._audio(MagicMock(), {"target": "123"})
+
+    text.assert_not_called()
+    voice.assert_called_once_with(raw=b"audio")
+    message.finish.assert_awaited_once_with()


### PR DESCRIPTION
## 背景
查询谱面信息后无法直接试听，需要额外的试听能力。

## 改动
- 新增 `/au [ID]` 指令：发送谱面 30 秒试听音频（mp3）。
  - 无 ID 时复用上下文：优先上一次查询的谱面（bid），其次谱面集（sid）；
  - 传入 bid 时先转 sid 拉取，失败再按原始 ID 作为 sid 拉取；
  - 发送前校验内容大小，排除错误页。
- `api.py`：新增 `get_preview_audio(sid)`，从 sayobot 双镜像（`cdn.sayobot.cn` / `a.sayobot.cn`）拉取试听音频，使用现有镜像健康度选择逻辑。

## 兼容性
- 不依赖新第三方库；音频源为公开静态资源；
- 非 OneBot 适配器同样可用（UniMessage 语音）。

## 测试
- `/au`（带 ID / 复用上下文）发送成功截图。
- 注：本改动自个人 fork 移植，建议本地验证后转正式 PR。