### PR TITLE
feat(preview): 使用 PyO3 原生渲染谱面预览

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ OSU_KEY=你的客户端密钥
 | `OSU_PREVIEW_STD_CATCH_FULL_SCALE` | `0.5` | osu!/Catch 完整视频缩放倍率 |
 | `OSU_PREVIEW_STD_CATCH_FULL_FRAME_INTERVAL` | `30` | osu!/Catch 完整视频帧间隔（毫秒） |
 
+
+### 二进制预览配置（osu-beatmap-preview，可选）
+
+使用 [osu-beatmap-preview](https://github.com/2710165659/osu-beatmap-preview)（Rust 单可执行文件，支持四种模式、GIF/PNG/MP4、转谱与变速）可替代默认的浏览器 + FFmpeg 渲染链路，速度更快且无需 FFmpeg。未配置二进制或渲染失败时自动回退旧链路（可用 `OSU_PREVIEW_FALLBACK` 关闭回退）。
+
+| 配置项 | 默认值 | 说明 |
+| --- | --- | --- |
+| `OSU_PREVIEW_BIN_PATH` | 无 | osu-beatmap-preview 可执行文件绝对路径；不配置则使用旧浏览器链路 |
+| `OSU_PREVIEW_USE_CORE` | `true` | 是否启用二进制渲染 |
+| `OSU_PREVIEW_FALLBACK` | `true` | 二进制缺失/失败时是否回退旧浏览器链路 |
+| `OSU_PREVIEW_TIMEOUT` | `120` | GIF/PNG 单次渲染超时（秒） |
+| `OSU_PREVIEW_VIDEO_TIMEOUT` | `300` | 完整 MP4 渲染超时（秒） |
+
+二进制请从项目的 [Releases](https://github.com/2710165659/osu-beatmap-preview/releases) 下载对应平台版本。
+
 ## ⚠️ 从 v6 升级到 v7
 
 v7 将底层 ORM 从 tortoise-orm 迁移至 nonebot-plugin-orm，**数据库表名和结构发生了变化**，升级前需手动执行迁移脚本，否则数据将丢失。

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ nonebot-plugin-osubot 提供 osu! 四种模式的玩家资料、成绩、BP 分�
 项目修改自 [osuv2](https://github.com/Yuri-YuzuChaN/osuv2)，并针对 NoneBot2 的命令交互、绘图和多平台使用进行了持续维护。
 
 > [!IMPORTANT]
-> 谱面变速和完整视频预览依赖 [FFmpeg](https://ffmpeg.org/download.html)。请先安装 FFmpeg 并确保可从 `PATH` 调用，或通过 `OSU_PREVIEW_FFMPEG_PATH` 指定可执行文件。
+> 原生谱面预览无需 FFmpeg；仅在原生渲染失败并回退旧完整视频链路时依赖
+> [FFmpeg](https://ffmpeg.org/download.html)。可将 FFmpeg 加入 `PATH`，或通过
+> `OSU_PREVIEW_FFMPEG_PATH` 指定可执行文件。
 
 ## 💿 安装
 
@@ -135,19 +137,12 @@ OSU_KEY=你的客户端密钥
 | `OSU_PREVIEW_STD_CATCH_FULL_FRAME_INTERVAL` | `30` | osu!/Catch 完整视频帧间隔（毫秒） |
 
 
-### 二进制预览配置（osu-beatmap-preview，可选）
+### 原生谱面预览
 
-使用 [osu-beatmap-preview](https://github.com/2710165659/osu-beatmap-preview)（Rust 单可执行文件，支持四种模式、GIF/PNG/MP4、转谱与变速）可替代默认的浏览器 + FFmpeg 渲染链路，速度更快且无需 FFmpeg。未配置二进制或渲染失败时自动回退旧链路（可用 `OSU_PREVIEW_FALLBACK` 关闭回退）。
-
-| 配置项 | 默认值 | 说明 |
-| --- | --- | --- |
-| `OSU_PREVIEW_BIN_PATH` | 无 | osu-beatmap-preview 可执行文件绝对路径；不配置则使用旧浏览器链路 |
-| `OSU_PREVIEW_USE_CORE` | `true` | 是否启用二进制渲染 |
-| `OSU_PREVIEW_FALLBACK` | `true` | 二进制缺失/失败时是否回退旧浏览器链路 |
-| `OSU_PREVIEW_TIMEOUT` | `120` | GIF/PNG 单次渲染超时（秒） |
-| `OSU_PREVIEW_VIDEO_TIMEOUT` | `300` | 完整 MP4 渲染超时（秒） |
-
-二进制请从项目的 [Releases](https://github.com/2710165659/osu-beatmap-preview/releases) 下载对应平台版本。
+插件通过 [osu-beatmap-preview-py](https://pypi.org/project/osu-beatmap-preview-py/)
+在 Python 进程内调用 Rust 渲染器，支持四种模式以及 GIF、PNG、MP4 输出。
+安装插件时会自动安装对应平台的预编译 wheel，无需下载可执行文件或新增配置；
+原生渲染失败时会自动回退现有浏览器渲染链路。
 
 ## ⚠️ 从 v6 升级到 v7
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "nonebot-plugin-htmlrender[playwright]>=0.8.0,<0.9",
     "nonebot-plugin-waiter>=0.6.1",
     "osu-tools-py>=0.1.4",
+    "osu-beatmap-preview-py>=0.1.0,<0.2.0",
     "rhythmgame-tools>=2.0.0",
     "nonebot-plugin-uninfo>=0.11.1",
     "resvg-py>=0.4.0,<0.5",

--- a/src/nonebot_plugin_osubot/config.py
+++ b/src/nonebot_plugin_osubot/config.py
@@ -22,6 +22,11 @@ class Config(BaseModel):
     osu_preview_taiko_full_frame_interval: int = 30
     osu_preview_std_catch_full_scale: float = 0.5
     osu_preview_std_catch_full_frame_interval: int = 30
+    osu_preview_bin_path: Optional[Path] = None
+    osu_preview_use_core: bool = True
+    osu_preview_fallback: bool = True
+    osu_preview_timeout: float = 120.0
+    osu_preview_video_timeout: float = 300.0
     osu_score_history_enabled: bool = True
     osu_score_history_sync_hour: int = Field(default=2, ge=0, le=23)
     osu_score_history_concurrency: int = Field(default=2, ge=1, le=20)

--- a/src/nonebot_plugin_osubot/config.py
+++ b/src/nonebot_plugin_osubot/config.py
@@ -22,11 +22,6 @@ class Config(BaseModel):
     osu_preview_taiko_full_frame_interval: int = 30
     osu_preview_std_catch_full_scale: float = 0.5
     osu_preview_std_catch_full_frame_interval: int = 30
-    osu_preview_bin_path: Optional[Path] = None
-    osu_preview_use_core: bool = True
-    osu_preview_fallback: bool = True
-    osu_preview_timeout: float = 120.0
-    osu_preview_video_timeout: float = 300.0
     osu_score_history_enabled: bool = True
     osu_score_history_sync_hour: int = Field(default=2, ge=0, le=23)
     osu_score_history_concurrency: int = Field(default=2, ge=1, le=20)

--- a/src/nonebot_plugin_osubot/draw/core_preview.py
+++ b/src/nonebot_plugin_osubot/draw/core_preview.py
@@ -1,0 +1,150 @@
+"""Rust 二进制 osu-beatmap-preview 的异步封装。
+
+调用本地编译好的 osu-beatmap-preview 可执行文件渲染谱面预览图/视频，
+替代原先基于浏览器(gif.js) + ffmpeg 的渲染链路。
+
+二进制 stdout 输出 JSON，产物绝对路径在 "preview-img" 字段。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Optional, Sequence
+
+logger = logging.getLogger("nonebot_plugin_osubot.core_preview")
+
+
+class CorePreviewError(Exception):
+    """core 渲染失败时抛出，供上层决定是否 fallback。"""
+
+
+# mode(int/str) -> 二进制的 --convert 取值。0/std 不需要 convert。
+_CONVERT_MAP = {
+    "0": None,
+    "1": "taiko",
+    "2": "ctb",
+    "3": "mania",
+}
+
+# 这些不是 osu 真实 mod，拼 --mods 时必须剔除（GIF 是插件自定义的伪 mod）。
+_NON_OSU_MODS = {"GI", "F", "GIF"}
+
+
+def _mode_to_convert(mode: int | str | None) -> Optional[str]:
+    if mode is None:
+        return None
+    return _CONVERT_MAP.get(str(mode))
+
+
+def mods_to_cli(mods: Optional[Sequence[str]]) -> Optional[str]:
+    """把 state["mods"]（如 ["HD","HR","GI","F"]）转成二进制的 --mods 串（如 "hd+hr"）。
+
+    - 剔除 GIF 伪 mod（可能被切成 "GI","F"，也可能整段 "GIF"）。
+    - 全小写，用 "+" 连接。
+    - 无有效 mod 时返回 None（不传 --mods）。
+    """
+    if not mods:
+        return None
+    cleaned = [m for m in mods if m and m.upper() not in _NON_OSU_MODS]
+    if not cleaned:
+        return None
+    return "+".join(m.lower() for m in cleaned)
+
+
+async def render_with_core(
+    bin_path: Path,
+    bid: int | str,
+    fmt: str,
+    *,
+    convert: Optional[str] = None,
+    mods: Optional[str] = None,
+    time: Optional[str] = None,
+    gif_clip: bool = False,
+    gif_clip_label: bool = False,
+    preview_30s: bool = False,
+    gap: Optional[int] = None,
+    no_cache: bool = False,
+    timeout: float = 120.0,
+) -> Path:
+    """调用二进制渲染，返回产物文件的绝对 Path。
+
+    Args:
+        bin_path: 二进制绝对路径。
+        bid: beatmap id。
+        fmt: "png" | "gif" | "mp4"。
+        convert: "taiko" | "ctb" | "mania" | None(std)。
+        mods: 已格式化的 mod 串，如 "hd+hr"。
+        time: 形如 "t1+t2"（秒）。仅截取片段时用；全曲 mp4 不要传。
+        gif_clip / gif_clip_label / preview_30s / gap / no_cache: 透传同名 flag。
+        timeout: 单次渲染超时（秒）。
+
+    Returns:
+        产物文件 Path（gif/png/mp4）。
+
+    Raises:
+        CorePreviewError: 二进制缺失、超时、非零退出、JSON 解析失败或产物不存在。
+    """
+    bin_path = Path(bin_path) if bin_path else None
+    if bin_path is None or not bin_path.is_file():
+        if bin_path is None:
+            raise CorePreviewError(
+                "未配置 osu_preview_bin_path（OSU_PREVIEW_BIN_PATH），无法使用二进制渲染，已回退旧链路"
+            )
+        raise CorePreviewError(f"osu-beatmap-preview 二进制不存在: {bin_path}")
+
+    cmd: list[str] = [str(bin_path), "--bid", str(bid), "--fmt", fmt]
+    if convert:
+        cmd += ["--convert", convert]
+    if mods:
+        cmd += ["--mods", mods]
+    if time:
+        cmd += ["--time", time]
+    if gif_clip:
+        cmd.append("--gif-clip")
+    if gif_clip_label:
+        cmd.append("--gif-clip-label")
+    if preview_30s:
+        cmd.append("--preview-30s")
+    if gap is not None:
+        cmd += ["--gap", str(gap)]
+    if no_cache:
+        cmd.append("--no-cache")
+
+    logger.debug("core_preview cmd: %s", " ".join(cmd))
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except FileNotFoundError as e:
+        raise CorePreviewError(f"无法启动二进制: {e}") from e
+    except asyncio.TimeoutError as e:
+        raise CorePreviewError(f"渲染超时({timeout}s): bid={bid} fmt={fmt}") from e
+
+    if proc.returncode != 0:
+        err = (stderr or b"").decode("utf-8", "ignore").strip()
+        raise CorePreviewError(f"二进制退出码 {proc.returncode}: {err[-500:]}")
+
+    out = (stdout or b"").decode("utf-8", "ignore").strip()
+    if not out:
+        raise CorePreviewError("二进制无 stdout 输出")
+
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError as e:
+        raise CorePreviewError(f"stdout 非合法 JSON: {out[:200]}") from e
+
+    img = data.get("preview-img")
+    if not img:
+        raise CorePreviewError(f"JSON 缺少 preview-img 字段: {data}")
+
+    p = Path(img)
+    if not p.is_file():
+        raise CorePreviewError(f"产物文件不存在: {p}")
+    return p

--- a/src/nonebot_plugin_osubot/draw/core_preview.py
+++ b/src/nonebot_plugin_osubot/draw/core_preview.py
@@ -1,151 +1,86 @@
-"""Rust 二进制 osu-beatmap-preview 的异步封装。
-
-调用本地编译好的 osu-beatmap-preview 可执行文件渲染谱面预览图/视频，
-替代原先基于浏览器(gif.js) + ffmpeg 的渲染链路。
-
-二进制 stdout 输出 JSON，产物绝对路径在 "preview-img" 字段。
-"""
+"""In-process adapter for the PyO3 osu! beatmap preview renderer."""
 
 from __future__ import annotations
 
 import asyncio
-import json
-import logging
 from pathlib import Path
-from typing import Optional
+from typing import Literal
 from collections.abc import Sequence
 
-logger = logging.getLogger("nonebot_plugin_osubot.core_preview")
+from nonebot import get_plugin_config
+from osu_beatmap_preview import PreviewError, generate_preview_async
+
+from ..config import Config
+
+PreviewFormat = Literal["png", "gif", "mp4"]
+ConvertMode = Literal["taiko", "ctb", "mania"]
 
 
-class CorePreviewError(Exception):
-    """core 渲染失败时抛出，供上层决定是否 fallback。"""
+class CorePreviewError(RuntimeError):
+    """Raised when the native renderer cannot produce a usable artifact."""
 
 
-# mode(int/str) -> 二进制的 --convert 取值。0/std 不需要 convert。
-_CONVERT_MAP = {
-    "0": None,
-    "1": "taiko",
-    "2": "ctb",
-    "3": "mania",
+_CONVERT_MAP: dict[int, ConvertMode] = {
+    1: "taiko",
+    2: "ctb",
+    3: "mania",
 }
-
-# 这些不是 osu 真实 mod，拼 --mods 时必须剔除（GIF 是插件自定义的伪 mod）。
 _NON_OSU_MODS = {"GI", "F", "GIF"}
+_plugin_config = get_plugin_config(Config)
+_render_semaphore = asyncio.Semaphore(_plugin_config.osu_render_max_concurrency)
 
 
-def _mode_to_convert(mode: int | str | None) -> Optional[str]:
-    if mode is None:
+def mode_to_convert(source_mode: int | None, target_mode: int | None) -> ConvertMode | None:
+    """Return a conversion only for standard maps targeting another ruleset."""
+    if source_mode != 0 or target_mode in {None, 0, source_mode}:
         return None
-    return _CONVERT_MAP.get(str(mode))
+    return _CONVERT_MAP.get(target_mode)
 
 
-def mods_to_cli(mods: Optional[Sequence[str]]) -> Optional[str]:
-    """把 state["mods"]（如 ["HD","HR","GI","F"]）转成二进制的 --mods 串（如 "hd+hr"）。
-
-    - 剔除 GIF 伪 mod（可能被切成 "GI","F"，也可能整段 "GIF"）。
-    - 全小写，用 "+" 连接。
-    - 无有效 mod 时返回 None（不传 --mods）。
-    """
+def mods_to_renderer(mods: Sequence[str] | None) -> str | None:
+    """Normalize osubot mods while dropping the matcher-only GIF marker."""
     if not mods:
         return None
-    cleaned = [m for m in mods if m and m.upper() not in _NON_OSU_MODS]
-    if not cleaned:
-        return None
-    return "+".join(m.lower() for m in cleaned)
+    cleaned = [mod.lower() for mod in mods if mod and mod.upper() not in _NON_OSU_MODS]
+    return "+".join(cleaned) or None
 
 
 async def render_with_core(
-    bin_path: Path,
-    bid: int | str,
-    fmt: str,
+    beatmap_id: int | str,
+    fmt: PreviewFormat,
     *,
-    convert: Optional[str] = None,
-    mods: Optional[str] = None,
-    time: Optional[str] = None,
-    gif_clip: bool = False,
-    gif_clip_label: bool = False,
-    preview_30s: bool = False,
-    gap: Optional[int] = None,
-    no_cache: bool = False,
-    timeout: float = 120.0,
+    source_mode: int | None = None,
+    target_mode: int | None = None,
+    mods: Sequence[str] | None = None,
+    time_range: str | None = None,
 ) -> Path:
-    """调用二进制渲染，返回产物文件的绝对 Path。
-
-    Args:
-        bin_path: 二进制绝对路径。
-        bid: beatmap id。
-        fmt: "png" | "gif" | "mp4"。
-        convert: "taiko" | "ctb" | "mania" | None(std)。
-        mods: 已格式化的 mod 串，如 "hd+hr"。
-        time: 形如 "t1+t2"（秒）。仅截取片段时用；全曲 mp4 不要传。
-        gif_clip / gif_clip_label / preview_30s / gap / no_cache: 透传同名 flag。
-        timeout: 单次渲染超时（秒）。
-
-    Returns:
-        产物文件 Path（gif/png/mp4）。
-
-    Raises:
-        CorePreviewError: 二进制缺失、超时、非零退出、JSON 解析失败或产物不存在。
-    """
-    bin_path = Path(bin_path) if bin_path else None
-    if bin_path is None or not bin_path.is_file():
-        if bin_path is None:
-            raise CorePreviewError(
-                "未配置 osu_preview_bin_path（OSU_PREVIEW_BIN_PATH），无法使用二进制渲染，已回退旧链路"
+    """Render a preview in-process and return its validated output path."""
+    try:
+        async with _render_semaphore:
+            result = await generate_preview_async(
+                beatmap_id,
+                format=fmt,
+                convert=mode_to_convert(source_mode, target_mode),
+                mods=mods_to_renderer(mods),
+                times=time_range,
             )
-        raise CorePreviewError(f"osu-beatmap-preview 二进制不存在: {bin_path}")
+        output = result.get("preview-img")
+        if not isinstance(output, str) or not output:
+            raise CorePreviewError("原生渲染结果缺少 preview-img")
 
-    cmd: list[str] = [str(bin_path), "--bid", str(bid), "--fmt", fmt]
-    if convert:
-        cmd += ["--convert", convert]
-    if mods:
-        cmd += ["--mods", mods]
-    if time:
-        cmd += ["--time", time]
-    if gif_clip:
-        cmd.append("--gif-clip")
-    if gif_clip_label:
-        cmd.append("--gif-clip-label")
-    if preview_30s:
-        cmd.append("--preview-30s")
-    if gap is not None:
-        cmd += ["--gap", str(gap)]
-    if no_cache:
-        cmd.append("--no-cache")
+        path = Path(output)
+        if not path.is_file() or path.stat().st_size == 0:
+            raise CorePreviewError(f"原生渲染产物不存在或为空: {path}")
+        return path
+    except CorePreviewError:
+        raise
+    except (PreviewError, OSError, TypeError, ValueError) as error:
+        raise CorePreviewError(f"原生渲染失败: {error}") from error
 
-    logger.debug("core_preview cmd: %s", " ".join(cmd))
 
+def read_core_output(path: Path) -> bytes:
+    """Read a native artifact while preserving the adapter's error contract."""
     try:
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except FileNotFoundError as e:
-        raise CorePreviewError(f"无法启动二进制: {e}") from e
-    except asyncio.TimeoutError as e:
-        raise CorePreviewError(f"渲染超时({timeout}s): bid={bid} fmt={fmt}") from e
-
-    if proc.returncode != 0:
-        err = (stderr or b"").decode("utf-8", "ignore").strip()
-        raise CorePreviewError(f"二进制退出码 {proc.returncode}: {err[-500:]}")
-
-    out = (stdout or b"").decode("utf-8", "ignore").strip()
-    if not out:
-        raise CorePreviewError("二进制无 stdout 输出")
-
-    try:
-        data = json.loads(out)
-    except json.JSONDecodeError as e:
-        raise CorePreviewError(f"stdout 非合法 JSON: {out[:200]}") from e
-
-    img = data.get("preview-img")
-    if not img:
-        raise CorePreviewError(f"JSON 缺少 preview-img 字段: {data}")
-
-    p = Path(img)
-    if not p.is_file():
-        raise CorePreviewError(f"产物文件不存在: {p}")
-    return p
+        return path.read_bytes()
+    except OSError as error:
+        raise CorePreviewError(f"读取原生渲染产物失败: {error}") from error

--- a/src/nonebot_plugin_osubot/draw/core_preview.py
+++ b/src/nonebot_plugin_osubot/draw/core_preview.py
@@ -84,3 +84,13 @@ def read_core_output(path: Path) -> bytes:
         return path.read_bytes()
     except OSError as error:
         raise CorePreviewError(f"读取原生渲染产物失败: {error}") from error
+
+
+def validate_core_output_readable(path: Path) -> None:
+    """Stream through a native artifact so read failures can trigger fallback."""
+    try:
+        with path.open("rb") as stream:
+            while stream.read(1024 * 1024):
+                pass
+    except OSError as error:
+        raise CorePreviewError(f"读取原生渲染产物失败: {error}") from error

--- a/src/nonebot_plugin_osubot/draw/core_preview.py
+++ b/src/nonebot_plugin_osubot/draw/core_preview.py
@@ -12,7 +12,8 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional
+from collections.abc import Sequence
 
 logger = logging.getLogger("nonebot_plugin_osubot.core_preview")
 

--- a/src/nonebot_plugin_osubot/draw/osu_preview.py
+++ b/src/nonebot_plugin_osubot/draw/osu_preview.py
@@ -5,10 +5,12 @@ import hashlib
 import shutil
 import tempfile
 import time
+from io import BytesIO
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Optional
 
 from nonebot import get_plugin_config
 from nonebot.log import logger
@@ -17,6 +19,12 @@ from ..config import Config
 from ..file import map_path
 from .browser import persistent_page
 from .utils import load_osu_file_and_setup_template
+from .core_preview import (
+    CorePreviewError,
+    mods_to_cli,
+    render_with_core,
+    _mode_to_convert,
+)
 
 template_path = str(Path(__file__).parent / "osu_preview_templates")
 taiko_skin_files = {
@@ -140,7 +148,8 @@ async def _render_gif_chunk(
     )
 
     async with persistent_page("osu_preview", None, {"width": 1280, "height": 720}) as page:
-        await page.set_content(html, wait_until="domcontentloaded")
+        await page.goto(f"file://{template_path}")
+        await page.set_content(html, wait_until="networkidle")
         await page.wait_for_function(
             f"() => document.querySelector('{img_selector}') &&"
             f" document.querySelector('{img_selector}').src.startsWith('blob:')",
@@ -238,7 +247,10 @@ async def _combine_gifs(chunk_paths: list[Path], output_path: Path) -> None:
         raise RuntimeError(f"FFmpeg 合成完整预览失败：{detail}")
 
 
-async def draw_full_osu_preview(
+# ===========================================================================
+# 旧链路（fallback）：原 draw_full_osu_preview / draw_osu_preview 函数体原样保留
+# ===========================================================================
+async def _legacy_draw_full_osu_preview(
     beatmap_id: int,
     beatmapset_id: int,
     progress_callback: Callable[[float], Awaitable[None]] | None = None,
@@ -357,14 +369,14 @@ async def draw_full_osu_preview(
     return cache_path
 
 
-async def draw_osu_preview(
+async def _legacy_draw_osu_preview(
     beatmap_id: int,
     beatmapset_id: int,
     full: bool = False,
     target_mode: int | None = None,
 ) -> bytes | Path:
     if full:
-        return await draw_full_osu_preview(beatmap_id, beatmapset_id, target_mode=target_mode)
+        return await _legacy_draw_full_osu_preview(beatmap_id, beatmapset_id, target_mode=target_mode)
 
     osu_file, template = await load_osu_file_and_setup_template(template_path, beatmap_id, beatmapset_id)
     osu_file = _convert_preview_mode(osu_file, target_mode)
@@ -378,3 +390,162 @@ async def draw_osu_preview(
         duration=10_000,
     )
     return chunk.data
+
+
+# ===========================================================================
+# core 链路
+# ===========================================================================
+async def _core_bytes(
+    bid: int,
+    sid: int,
+    target_mode: int | None,
+    mods: Optional[Sequence[str]],
+    fmt: str = "gif",
+    time_range: Optional[str] = None,
+) -> bytes:
+    p = await render_with_core(
+        plugin_config.osu_preview_bin_path,
+        bid,
+        fmt=fmt,
+        convert=_mode_to_convert(target_mode),
+        mods=mods_to_cli(mods),
+        time=time_range,
+        timeout=plugin_config.osu_preview_timeout,
+    )
+    return p.read_bytes()
+
+
+async def _core_full_video(
+    bid: int,
+    sid: int,
+    target_mode: int | None,
+    mods: Optional[Sequence[str]],
+) -> Path:
+    # 完整 mp4：--fmt=mp4，不传 --time、不传 --preview-30s => 全曲
+    return await render_with_core(
+        plugin_config.osu_preview_bin_path,
+        bid,
+        fmt="mp4",
+        convert=_mode_to_convert(target_mode),
+        mods=mods_to_cli(mods),
+        timeout=plugin_config.osu_preview_video_timeout,
+    )
+
+
+def _to_bytes(result) -> bytes:
+    """把 bytes / BytesIO / Path 统一成 bytes。"""
+    if isinstance(result, (bytes, bytearray)):
+        return bytes(result)
+    if isinstance(result, BytesIO):
+        return result.getvalue()
+    if isinstance(result, Path):
+        return result.read_bytes()
+    return bytes(result)
+
+
+# ===========================================================================
+# 对外 API（保持/扩展原签名）
+# ===========================================================================
+async def draw_osu_preview(
+    beatmap_id: int,
+    beatmapset_id: int,
+    full: bool = False,
+    target_mode: int | None = None,
+    mods: Optional[Sequence[str]] = None,
+) -> bytes | Path:
+    """full=False -> gif bytes；full=True -> 完整 mp4 Path。优先 core，失败按配置回退。"""
+    if full:
+        return await draw_full_osu_preview(
+            beatmap_id, beatmapset_id, target_mode=target_mode, mods=mods
+        )
+
+    if plugin_config.osu_preview_use_core:
+        try:
+            return await _core_bytes(beatmap_id, beatmapset_id, target_mode, mods, fmt="gif")
+        except CorePreviewError as e:
+            if not plugin_config.osu_preview_fallback:
+                raise
+            logger.warning("core gif 渲染失败，回退旧链路: %s", e)
+    return await _legacy_draw_osu_preview(
+        beatmap_id, beatmapset_id, full=False, target_mode=target_mode
+    )
+
+
+async def draw_full_osu_preview(
+    beatmap_id: int,
+    beatmapset_id: int,
+    progress_callback: Callable[[float], Awaitable[None]] | None = None,
+    target_mode: int | None = None,
+    mods: Optional[Sequence[str]] = None,
+) -> Path:
+    """完整 mp4 Path。core 模式无分片进度，progress_callback 仅 fallback 旧链路生效。"""
+    if plugin_config.osu_preview_use_core:
+        try:
+            return await _core_full_video(beatmap_id, beatmapset_id, target_mode, mods)
+        except CorePreviewError as e:
+            if not plugin_config.osu_preview_fallback:
+                raise
+            logger.warning("core 完整视频失败，回退旧链路: %s", e)
+    return await _legacy_draw_full_osu_preview(
+        beatmap_id, beatmapset_id, progress_callback=progress_callback, target_mode=target_mode
+    )
+
+
+# ===========================================================================
+# 统一入口：std / taiko / catch / mania 都走这里
+# ===========================================================================
+async def render_preview(
+    bid: int,
+    sid: int,
+    mode: int,
+    *,
+    fmt: str = "png",
+    mods: Optional[Sequence[str]] = None,
+    time_range: Optional[str] = None,
+    progress_callback: Callable[[float], Awaitable[None]] | None = None,
+) -> bytes | Path:
+    """统一渲染入口。
+
+    fmt:
+      "png" / "gif" -> 返回 bytes
+      "mp4"         -> 返回 Path（完整视频，等价 draw_full_osu_preview）
+    """
+    mode = int(mode)
+
+    if fmt == "mp4":
+        return await draw_full_osu_preview(
+            bid, sid, progress_callback=progress_callback, target_mode=mode, mods=mods
+        )
+
+    if plugin_config.osu_preview_use_core:
+        try:
+            return await _core_bytes(bid, sid, mode, mods, fmt=fmt, time_range=time_range)
+        except CorePreviewError as e:
+            if not plugin_config.osu_preview_fallback:
+                raise
+            logger.warning("core 渲染失败，回退旧链路: mode=%s fmt=%s %s", mode, fmt, e)
+
+    # ---- fallback ----
+    if fmt == "gif":
+        # 旧浏览器链路自带模式转换（_convert_preview_mode），任意 mode 都适用
+        return await _legacy_draw_osu_preview(bid, sid, full=False, target_mode=mode)
+
+    # fmt == "png"：按模式走各自旧实现
+    if mode == 1:
+        from ..file import download_osu
+        from .taiko_preview import parse_map, map_to_image
+
+        osu = await download_osu(sid, bid)
+        return _to_bytes(map_to_image(parse_map(osu)))
+    if mode == 2:
+        from .catch_preview import draw_cath_preview
+
+        return _to_bytes(await draw_cath_preview(bid, sid, mods or []))
+    if mode == 3:
+        from ..file import download_osu
+        from ..mania import generate_preview_pic
+
+        osu = await download_osu(sid, bid)
+        return _to_bytes(await generate_preview_pic(osu))
+    # mode 0 要 png 的旧实现不存在，退化为 gif bytes
+    return await _legacy_draw_osu_preview(bid, sid, full=False, target_mode=0)

--- a/src/nonebot_plugin_osubot/draw/osu_preview.py
+++ b/src/nonebot_plugin_osubot/draw/osu_preview.py
@@ -1,29 +1,29 @@
 import re
-import asyncio
-import base64
-import hashlib
-import shutil
-import tempfile
 import time
+import base64
+import shutil
+import asyncio
+import hashlib
+import tempfile
 from io import BytesIO
-from dataclasses import dataclass
-from functools import lru_cache
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Sequence
-from typing import Optional
+from functools import lru_cache
+from dataclasses import dataclass
+from typing import TypeVar, Optional
+from collections.abc import Callable, Sequence, Awaitable
 
-from nonebot import get_plugin_config
 from nonebot.log import logger
+from nonebot import get_plugin_config
 
 from ..config import Config
 from ..file import map_path
 from .browser import persistent_page
 from .utils import load_osu_file_and_setup_template
 from .core_preview import (
+    PreviewFormat,
     CorePreviewError,
-    mods_to_cli,
+    read_core_output,
     render_with_core,
-    _mode_to_convert,
 )
 
 template_path = str(Path(__file__).parent / "osu_preview_templates")
@@ -397,39 +397,53 @@ async def _legacy_draw_osu_preview(
 # ===========================================================================
 async def _core_bytes(
     bid: int,
-    sid: int,
+    source_mode: int | None,
     target_mode: int | None,
     mods: Optional[Sequence[str]],
-    fmt: str = "gif",
+    fmt: PreviewFormat = "gif",
     time_range: Optional[str] = None,
 ) -> bytes:
     p = await render_with_core(
-        plugin_config.osu_preview_bin_path,
         bid,
         fmt=fmt,
-        convert=_mode_to_convert(target_mode),
-        mods=mods_to_cli(mods),
-        time=time_range,
-        timeout=plugin_config.osu_preview_timeout,
+        source_mode=source_mode,
+        target_mode=target_mode,
+        mods=mods,
+        time_range=time_range,
     )
-    return p.read_bytes()
+    return read_core_output(p)
 
 
 async def _core_full_video(
     bid: int,
-    sid: int,
+    source_mode: int | None,
     target_mode: int | None,
     mods: Optional[Sequence[str]],
 ) -> Path:
-    # 完整 mp4：--fmt=mp4，不传 --time、不传 --preview-30s => 全曲
     return await render_with_core(
-        plugin_config.osu_preview_bin_path,
         bid,
         fmt="mp4",
-        convert=_mode_to_convert(target_mode),
-        mods=mods_to_cli(mods),
-        timeout=plugin_config.osu_preview_video_timeout,
+        source_mode=source_mode,
+        target_mode=target_mode,
+        mods=mods,
     )
+
+
+_RenderResult = TypeVar("_RenderResult")
+
+
+async def _prefer_core(
+    core: Callable[[], Awaitable[_RenderResult]],
+    fallback: Callable[[], Awaitable[_RenderResult]],
+    *,
+    label: str,
+) -> _RenderResult:
+    """Apply the native-first fallback policy in one place."""
+    try:
+        return await core()
+    except CorePreviewError as error:
+        logger.warning("%s原生渲染失败，回退旧链路: %s", label, error)
+        return await fallback()
 
 
 def _to_bytes(result) -> bytes:
@@ -452,19 +466,23 @@ async def draw_osu_preview(
     full: bool = False,
     target_mode: int | None = None,
     mods: Optional[Sequence[str]] = None,
+    source_mode: int | None = None,
 ) -> bytes | Path:
-    """full=False -> gif bytes；full=True -> 完整 mp4 Path。优先 core，失败按配置回退。"""
+    """Render GIF bytes or a complete MP4 with an automatic legacy fallback."""
     if full:
-        return await draw_full_osu_preview(beatmap_id, beatmapset_id, target_mode=target_mode, mods=mods)
+        return await draw_full_osu_preview(
+            beatmap_id,
+            beatmapset_id,
+            target_mode=target_mode,
+            mods=mods,
+            source_mode=source_mode,
+        )
 
-    if plugin_config.osu_preview_use_core:
-        try:
-            return await _core_bytes(beatmap_id, beatmapset_id, target_mode, mods, fmt="gif")
-        except CorePreviewError as e:
-            if not plugin_config.osu_preview_fallback:
-                raise
-            logger.warning("core gif 渲染失败，回退旧链路: %s", e)
-    return await _legacy_draw_osu_preview(beatmap_id, beatmapset_id, full=False, target_mode=target_mode)
+    return await _prefer_core(
+        lambda: _core_bytes(beatmap_id, source_mode, target_mode, mods, fmt="gif"),
+        lambda: _legacy_draw_osu_preview(beatmap_id, beatmapset_id, full=False, target_mode=target_mode),
+        label="GIF ",
+    )
 
 
 async def draw_full_osu_preview(
@@ -473,17 +491,27 @@ async def draw_full_osu_preview(
     progress_callback: Callable[[float], Awaitable[None]] | None = None,
     target_mode: int | None = None,
     mods: Optional[Sequence[str]] = None,
+    source_mode: int | None = None,
 ) -> Path:
-    """完整 mp4 Path。core 模式无分片进度，progress_callback 仅 fallback 旧链路生效。"""
-    if plugin_config.osu_preview_use_core:
-        try:
-            return await _core_full_video(beatmap_id, beatmapset_id, target_mode, mods)
-        except CorePreviewError as e:
-            if not plugin_config.osu_preview_fallback:
-                raise
-            logger.warning("core 完整视频失败，回退旧链路: %s", e)
-    return await _legacy_draw_full_osu_preview(
-        beatmap_id, beatmapset_id, progress_callback=progress_callback, target_mode=target_mode
+    """Render a complete MP4; progress callbacks apply to the legacy fallback."""
+
+    async def render_core() -> Path:
+        if progress_callback is not None:
+            try:
+                await progress_callback(60.0)
+            except Exception:
+                logger.exception("发送原生完整预览预计时间失败")
+        return await _core_full_video(beatmap_id, source_mode, target_mode, mods)
+
+    return await _prefer_core(
+        render_core,
+        lambda: _legacy_draw_full_osu_preview(
+            beatmap_id,
+            beatmapset_id,
+            progress_callback=progress_callback,
+            target_mode=target_mode,
+        ),
+        label="完整视频 ",
     )
 
 
@@ -495,10 +523,12 @@ async def render_preview(
     sid: int,
     mode: int,
     *,
-    fmt: str = "png",
+    fmt: PreviewFormat = "png",
     mods: Optional[Sequence[str]] = None,
     time_range: Optional[str] = None,
     progress_callback: Callable[[float], Awaitable[None]] | None = None,
+    source_mode: int | None = None,
+    full_image: bool = False,
 ) -> bytes | Path:
     """统一渲染入口。
 
@@ -509,37 +539,38 @@ async def render_preview(
     mode = int(mode)
 
     if fmt == "mp4":
-        return await draw_full_osu_preview(bid, sid, progress_callback=progress_callback, target_mode=mode, mods=mods)
+        return await draw_full_osu_preview(
+            bid,
+            sid,
+            progress_callback=progress_callback,
+            target_mode=mode,
+            mods=mods,
+            source_mode=source_mode,
+        )
 
-    if plugin_config.osu_preview_use_core:
-        try:
-            return await _core_bytes(bid, sid, mode, mods, fmt=fmt, time_range=time_range)
-        except CorePreviewError as e:
-            if not plugin_config.osu_preview_fallback:
-                raise
-            logger.warning("core 渲染失败，回退旧链路: mode=%s fmt=%s %s", mode, fmt, e)
+    async def fallback() -> bytes:
+        if fmt == "gif":
+            return await _legacy_draw_osu_preview(bid, sid, full=False, target_mode=mode)
+        if mode == 1:
+            from ..file import download_osu
+            from .taiko_preview import parse_map, map_to_image
 
-    # ---- fallback ----
-    if fmt == "gif":
-        # 旧浏览器链路自带模式转换（_convert_preview_mode），任意 mode 都适用
-        return await _legacy_draw_osu_preview(bid, sid, full=False, target_mode=mode)
+            osu = await download_osu(sid, bid)
+            return _to_bytes(map_to_image(parse_map(osu)))
+        if mode == 2:
+            from .catch_preview import draw_cath_preview
 
-    # fmt == "png"：按模式走各自旧实现
-    if mode == 1:
-        from ..file import download_osu
-        from .taiko_preview import parse_map, map_to_image
+            return _to_bytes(await draw_cath_preview(bid, sid, mods or []))
+        if mode == 3:
+            from ..file import download_osu
+            from ..mania import generate_preview_pic
 
-        osu = await download_osu(sid, bid)
-        return _to_bytes(map_to_image(parse_map(osu)))
-    if mode == 2:
-        from .catch_preview import draw_cath_preview
+            osu = await download_osu(sid, bid)
+            return _to_bytes(await generate_preview_pic(osu, full_image))
+        return await _legacy_draw_osu_preview(bid, sid, full=False, target_mode=0)
 
-        return _to_bytes(await draw_cath_preview(bid, sid, mods or []))
-    if mode == 3:
-        from ..file import download_osu
-        from ..mania import generate_preview_pic
-
-        osu = await download_osu(sid, bid)
-        return _to_bytes(await generate_preview_pic(osu))
-    # mode 0 要 png 的旧实现不存在，退化为 gif bytes
-    return await _legacy_draw_osu_preview(bid, sid, full=False, target_mode=0)
+    return await _prefer_core(
+        lambda: _core_bytes(bid, source_mode, mode, mods, fmt=fmt, time_range=time_range),
+        fallback,
+        label=f"{mode=} {fmt=} ",
+    )

--- a/src/nonebot_plugin_osubot/draw/osu_preview.py
+++ b/src/nonebot_plugin_osubot/draw/osu_preview.py
@@ -24,6 +24,7 @@ from .core_preview import (
     CorePreviewError,
     read_core_output,
     render_with_core,
+    validate_core_output_readable,
 )
 
 template_path = str(Path(__file__).parent / "osu_preview_templates")
@@ -148,7 +149,7 @@ async def _render_gif_chunk(
     )
 
     async with persistent_page("osu_preview", None, {"width": 1280, "height": 720}) as page:
-        await page.goto(f"file://{template_path}")
+        await page.goto(base_url)
         await page.set_content(html, wait_until="networkidle")
         await page.wait_for_function(
             f"() => document.querySelector('{img_selector}') &&"
@@ -393,7 +394,7 @@ async def _legacy_draw_osu_preview(
 
 
 # ===========================================================================
-# core 链路
+# PyO3 原生渲染链路
 # ===========================================================================
 async def _core_bytes(
     bid: int,
@@ -420,13 +421,15 @@ async def _core_full_video(
     target_mode: int | None,
     mods: Optional[Sequence[str]],
 ) -> Path:
-    return await render_with_core(
+    path = await render_with_core(
         bid,
         fmt="mp4",
         source_mode=source_mode,
         target_mode=target_mode,
         mods=mods,
     )
+    validate_core_output_readable(path)
+    return path
 
 
 _RenderResult = TypeVar("_RenderResult")
@@ -493,14 +496,22 @@ async def draw_full_osu_preview(
     mods: Optional[Sequence[str]] = None,
     source_mode: int | None = None,
 ) -> Path:
-    """Render a complete MP4; progress callbacks apply to the legacy fallback."""
+    """Render a complete MP4 and emit at most one time estimate."""
+    estimate_sent = False
+
+    async def send_estimate_once(seconds: float) -> None:
+        nonlocal estimate_sent
+        if progress_callback is None or estimate_sent:
+            return
+        try:
+            await progress_callback(seconds)
+        except Exception:
+            logger.exception("发送完整预览预计时间失败")
+        else:
+            estimate_sent = True
 
     async def render_core() -> Path:
-        if progress_callback is not None:
-            try:
-                await progress_callback(60.0)
-            except Exception:
-                logger.exception("发送原生完整预览预计时间失败")
+        await send_estimate_once(60.0)
         return await _core_full_video(beatmap_id, source_mode, target_mode, mods)
 
     return await _prefer_core(
@@ -508,7 +519,7 @@ async def draw_full_osu_preview(
         lambda: _legacy_draw_full_osu_preview(
             beatmap_id,
             beatmapset_id,
-            progress_callback=progress_callback,
+            progress_callback=send_estimate_once if progress_callback is not None else None,
             target_mode=target_mode,
         ),
         label="完整视频 ",

--- a/src/nonebot_plugin_osubot/draw/osu_preview.py
+++ b/src/nonebot_plugin_osubot/draw/osu_preview.py
@@ -455,9 +455,7 @@ async def draw_osu_preview(
 ) -> bytes | Path:
     """full=False -> gif bytes；full=True -> 完整 mp4 Path。优先 core，失败按配置回退。"""
     if full:
-        return await draw_full_osu_preview(
-            beatmap_id, beatmapset_id, target_mode=target_mode, mods=mods
-        )
+        return await draw_full_osu_preview(beatmap_id, beatmapset_id, target_mode=target_mode, mods=mods)
 
     if plugin_config.osu_preview_use_core:
         try:
@@ -466,9 +464,7 @@ async def draw_osu_preview(
             if not plugin_config.osu_preview_fallback:
                 raise
             logger.warning("core gif 渲染失败，回退旧链路: %s", e)
-    return await _legacy_draw_osu_preview(
-        beatmap_id, beatmapset_id, full=False, target_mode=target_mode
-    )
+    return await _legacy_draw_osu_preview(beatmap_id, beatmapset_id, full=False, target_mode=target_mode)
 
 
 async def draw_full_osu_preview(
@@ -513,9 +509,7 @@ async def render_preview(
     mode = int(mode)
 
     if fmt == "mp4":
-        return await draw_full_osu_preview(
-            bid, sid, progress_callback=progress_callback, target_mode=mode, mods=mods
-        )
+        return await draw_full_osu_preview(bid, sid, progress_callback=progress_callback, target_mode=mode, mods=mods)
 
     if plugin_config.osu_preview_use_core:
         try:

--- a/src/nonebot_plugin_osubot/matcher/preview.py
+++ b/src/nonebot_plugin_osubot/matcher/preview.py
@@ -9,12 +9,8 @@ from ..utils import NGM, normalize_map_mode
 from ..api import osu_api
 from .utils import split_msg
 from .map_context import get_last_map_id, remember_map_and_set
-from ..file import download_osu
 from ..exceptions import NetworkError
-from ..mania import generate_preview_pic
-from ..draw.osu_preview import draw_osu_preview, draw_full_osu_preview
-from ..draw.catch_preview import draw_cath_preview
-from ..draw.taiko_preview import parse_map, map_to_image
+from ..draw.osu_preview import draw_osu_preview, draw_full_osu_preview, render_preview
 
 video_preview_commands = {"视频预览", "完整视频", "vpreview", "vp"}
 generate_preview = on_command(
@@ -55,57 +51,74 @@ async def _(event: Event, state: T_State):
 
     command = state["_prefix"]["command"][0]
     is_video_command = command in video_preview_commands
-    if is_video_command or is_gif_preview(state):
-        is_full = command == "完整预览" or is_video_command
-        if is_full:
+    want_gif = is_gif_preview(state)
+    is_full = command == "完整预览" or is_video_command
+    mode_int = int(state["mode"])
 
-            async def send_estimate(seconds: float) -> None:
-                if seconds < 15:
-                    return
-                estimate = format_estimated_time(seconds)
-                await UniMessage.text(f"正在生成完整预览，预计还需约{estimate}，请稍候…").send(reply_to=True)
+    # ------------------------------------------------------------------
+    # 完整视频：视频命令 / 完整预览（无论是否带 +GIF），所有模式统一 mp4。
+    # 【行为变更】旧代码里 "完整预览"(不带+GIF) 的 std 分支只发 10s gif、
+    # mania 发整张静态图；现在统一为完整 mp4。如需恢复旧行为，把这里改成
+    # 按 mode 分支调用 render_preview(fmt="png"/"gif") 即可。
+    # ------------------------------------------------------------------
+    if is_full:
+        # core 链路没有分片进度，开头先发一句固定提示（A 决策）；
+        # 若回退到旧链路，send_estimate 仍会在采样后补发预计时间。
+        await UniMessage.text("正在生成完整预览，请稍候…").send(reply_to=True)
 
-            video = await draw_full_osu_preview(
-                int(osu_id),
-                data["beatmapset_id"],
-                progress_callback=send_estimate,
-                target_mode=int(state["mode"]),
-            )
-            msg = UniMessage.video(raw=video.read_bytes(), name=video.name)
-        else:
-            pic = await draw_osu_preview(
-                int(osu_id),
-                data["beatmapset_id"],
-                False,
-                target_mode=int(state["mode"]),
-            )
-            msg = UniMessage.image(raw=pic)
+        async def send_estimate(seconds: float) -> None:
+            if seconds < 15:
+                return
+            estimate = format_estimated_time(seconds)
+            await UniMessage.text(f"正在生成完整预览，预计还需约{estimate}，请稍候…").send(reply_to=True)
+
+        video = await draw_full_osu_preview(
+            int(osu_id),
+            data["beatmapset_id"],
+            progress_callback=send_estimate,
+            target_mode=mode_int,
+            mods=state["mods"],
+        )
+        msg = UniMessage.video(raw=video.read_bytes(), name=video.name)
         if state["mode"] == "0":
             msg += UniMessage.text(
                 f"点击预览：\nhttps://beatmap.try-z.net/?b={osu_id}\nhttps://beatmap.try-z.net/dev/?b={osu_id}"
             )
-        await msg.finish(reply_to=not is_full)
+        await msg.finish(reply_to=False)
 
-    if state["mode"] == "3":
-        osu = await download_osu(data["beatmapset_id"], int(osu_id))
-        if state["_prefix"]["command"][0] == "完整预览":
-            pic = await generate_preview_pic(osu, True)
-        else:
-            pic = await generate_preview_pic(osu)
-        await UniMessage.image(raw=pic).finish(reply_to=True)
-    elif state["mode"] == "2":
-        pic = await draw_cath_preview(int(osu_id), data["beatmapset_id"], state["mods"])
-        await UniMessage.image(raw=pic).finish(reply_to=True)
-    elif state["mode"] == "1":
-        osu = await download_osu(data["beatmapset_id"], int(osu_id))
-        beatmap = parse_map(osu)
-        pic = map_to_image(beatmap)
-        await UniMessage.image(raw=pic).finish(reply_to=True)
-    elif state["mode"] == "0":
-        pic = await draw_osu_preview(int(osu_id), data["beatmapset_id"])
+    # ------------------------------------------------------------------
+    # GIF 预览（+GIF，非完整）：任意模式 -> binary --fmt=gif --convert=...
+    # ------------------------------------------------------------------
+    if want_gif:
+        pic = await draw_osu_preview(
+            int(osu_id),
+            data["beatmapset_id"],
+            False,
+            target_mode=mode_int,
+            mods=state["mods"],
+        )
+        msg = UniMessage.image(raw=pic)
+        if state["mode"] == "0":
+            msg += UniMessage.text(
+                f"点击预览：\nhttps://beatmap.try-z.net/?b={osu_id}\nhttps://beatmap.try-z.net/dev/?b={osu_id}"
+            )
+        await msg.finish(reply_to=True)
+
+    # ------------------------------------------------------------------
+    # 静态预览：std -> gif（保持旧 UX）；taiko/ctb/mania -> png
+    # ------------------------------------------------------------------
+    if state["mode"] == "0":
+        pic = await render_preview(
+            int(osu_id), data["beatmapset_id"], 0, fmt="gif", mods=state["mods"]
+        )
         msg = UniMessage.image(raw=pic) + UniMessage.text(
             f"点击预览：\nhttps://beatmap.try-z.net/?b={osu_id}\nhttps://beatmap.try-z.net/dev/?b={osu_id}"
         )
         await msg.finish(reply_to=True)
+    elif state["mode"] in ("1", "2", "3"):
+        pic = await render_preview(
+            int(osu_id), data["beatmapset_id"], mode_int, fmt="png", mods=state["mods"]
+        )
+        await UniMessage.image(raw=pic).finish(reply_to=True)
     else:
         await UniMessage.text(f"{NGM[state['mode']]}模式暂不支持预览").finish()

--- a/src/nonebot_plugin_osubot/matcher/preview.py
+++ b/src/nonebot_plugin_osubot/matcher/preview.py
@@ -108,17 +108,13 @@ async def _(event: Event, state: T_State):
     # 静态预览：std -> gif（保持旧 UX）；taiko/ctb/mania -> png
     # ------------------------------------------------------------------
     if state["mode"] == "0":
-        pic = await render_preview(
-            int(osu_id), data["beatmapset_id"], 0, fmt="gif", mods=state["mods"]
-        )
+        pic = await render_preview(int(osu_id), data["beatmapset_id"], 0, fmt="gif", mods=state["mods"])
         msg = UniMessage.image(raw=pic) + UniMessage.text(
             f"点击预览：\nhttps://beatmap.try-z.net/?b={osu_id}\nhttps://beatmap.try-z.net/dev/?b={osu_id}"
         )
         await msg.finish(reply_to=True)
     elif state["mode"] in ("1", "2", "3"):
-        pic = await render_preview(
-            int(osu_id), data["beatmapset_id"], mode_int, fmt="png", mods=state["mods"]
-        )
+        pic = await render_preview(int(osu_id), data["beatmapset_id"], mode_int, fmt="png", mods=state["mods"])
         await UniMessage.image(raw=pic).finish(reply_to=True)
     else:
         await UniMessage.text(f"{NGM[state['mode']]}模式暂不支持预览").finish()

--- a/src/nonebot_plugin_osubot/matcher/preview.py
+++ b/src/nonebot_plugin_osubot/matcher/preview.py
@@ -83,7 +83,7 @@ async def _(event: Event, state: T_State):
         await msg.finish(reply_to=False)
 
     # ------------------------------------------------------------------
-    # GIF 预览（+GIF，非完整）：任意模式 -> binary --fmt=gif --convert=...
+    # GIF 预览（+GIF，非完整）：任意模式均通过 PyO3 原生渲染器输出 GIF。
     # ------------------------------------------------------------------
     if want_gif:
         pic = await draw_osu_preview(

--- a/src/nonebot_plugin_osubot/matcher/preview.py
+++ b/src/nonebot_plugin_osubot/matcher/preview.py
@@ -5,12 +5,12 @@ from nonebot.typing import T_State
 from nonebot.internal.adapter import Event
 from nonebot_plugin_alconna import UniMessage
 
-from ..utils import NGM, normalize_map_mode
 from ..api import osu_api
 from .utils import split_msg
-from .map_context import get_last_map_id, remember_map_and_set
 from ..exceptions import NetworkError
-from ..draw.osu_preview import draw_osu_preview, draw_full_osu_preview, render_preview
+from ..utils import NGM, normalize_map_mode
+from .map_context import get_last_map_id, remember_map_and_set
+from ..draw.osu_preview import render_preview, draw_osu_preview, draw_full_osu_preview
 
 video_preview_commands = {"视频预览", "完整视频", "vpreview", "vp"}
 generate_preview = on_command(
@@ -52,19 +52,14 @@ async def _(event: Event, state: T_State):
     command = state["_prefix"]["command"][0]
     is_video_command = command in video_preview_commands
     want_gif = is_gif_preview(state)
-    is_full = command == "完整预览" or is_video_command
+    is_full_video = is_video_command or (command == "完整预览" and want_gif)
     mode_int = int(state["mode"])
+    source_mode = int(data["mode_int"])
 
     # ------------------------------------------------------------------
-    # 完整视频：视频命令 / 完整预览（无论是否带 +GIF），所有模式统一 mp4。
-    # 【行为变更】旧代码里 "完整预览"(不带+GIF) 的 std 分支只发 10s gif、
-    # mania 发整张静态图；现在统一为完整 mp4。如需恢复旧行为，把这里改成
-    # 按 mode 分支调用 render_preview(fmt="png"/"gif") 即可。
+    # 完整视频：视频命令，或带 +GIF 的完整预览。
     # ------------------------------------------------------------------
-    if is_full:
-        # core 链路没有分片进度，开头先发一句固定提示（A 决策）；
-        # 若回退到旧链路，send_estimate 仍会在采样后补发预计时间。
-        await UniMessage.text("正在生成完整预览，请稍候…").send(reply_to=True)
+    if is_full_video:
 
         async def send_estimate(seconds: float) -> None:
             if seconds < 15:
@@ -78,6 +73,7 @@ async def _(event: Event, state: T_State):
             progress_callback=send_estimate,
             target_mode=mode_int,
             mods=state["mods"],
+            source_mode=source_mode,
         )
         msg = UniMessage.video(raw=video.read_bytes(), name=video.name)
         if state["mode"] == "0":
@@ -96,6 +92,7 @@ async def _(event: Event, state: T_State):
             False,
             target_mode=mode_int,
             mods=state["mods"],
+            source_mode=source_mode,
         )
         msg = UniMessage.image(raw=pic)
         if state["mode"] == "0":
@@ -108,13 +105,28 @@ async def _(event: Event, state: T_State):
     # 静态预览：std -> gif（保持旧 UX）；taiko/ctb/mania -> png
     # ------------------------------------------------------------------
     if state["mode"] == "0":
-        pic = await render_preview(int(osu_id), data["beatmapset_id"], 0, fmt="gif", mods=state["mods"])
+        pic = await render_preview(
+            int(osu_id),
+            data["beatmapset_id"],
+            0,
+            fmt="gif",
+            mods=state["mods"],
+            source_mode=source_mode,
+        )
         msg = UniMessage.image(raw=pic) + UniMessage.text(
             f"点击预览：\nhttps://beatmap.try-z.net/?b={osu_id}\nhttps://beatmap.try-z.net/dev/?b={osu_id}"
         )
         await msg.finish(reply_to=True)
     elif state["mode"] in ("1", "2", "3"):
-        pic = await render_preview(int(osu_id), data["beatmapset_id"], mode_int, fmt="png", mods=state["mods"])
+        pic = await render_preview(
+            int(osu_id),
+            data["beatmapset_id"],
+            mode_int,
+            fmt="png",
+            mods=state["mods"],
+            source_mode=source_mode,
+            full_image=command == "完整预览",
+        )
         await UniMessage.image(raw=pic).finish(reply_to=True)
     else:
         await UniMessage.text(f"{NGM[state['mode']]}模式暂不支持预览").finish()

--- a/tests/test_bp.py
+++ b/tests/test_bp.py
@@ -123,7 +123,7 @@ async def test_bp_success(app: App):
                 new=AsyncMock(return_value={"beatmapset_id": 13579, "mode_int": 0}),
             ) as get_map,
             patch(
-                "nonebot_plugin_osubot.matcher.preview.draw_osu_preview",
+                "nonebot_plugin_osubot.matcher.preview.render_preview",
                 new=AsyncMock(return_value=FAKE_IMG),
             ) as draw_preview,
         ):
@@ -143,7 +143,14 @@ async def test_bp_success(app: App):
 
     draw_map.assert_awaited_once_with("24680", [])
     get_map.assert_awaited_once_with("map", map_id=24680)
-    draw_preview.assert_awaited_once_with(24680, 13579)
+    draw_preview.assert_awaited_once_with(
+        24680,
+        13579,
+        0,
+        fmt="gif",
+        mods=[],
+        source_mode=0,
+    )
     assert draw_score.call_args.args[2] is True
 
 

--- a/tests/test_core_preview.py
+++ b/tests/test_core_preview.py
@@ -43,6 +43,18 @@ async def test_core_adapter_rejects_missing_output(monkeypatch: pytest.MonkeyPat
         await core_preview.render_with_core(123, "png")
 
 
+def test_core_adapter_wraps_artifact_read_failures(monkeypatch: pytest.MonkeyPatch):
+    from nonebot_plugin_osubot.draw import core_preview
+
+    def fail_open(_path: Path, *_args: object, **_kwargs: object):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "open", fail_open)
+
+    with pytest.raises(core_preview.CorePreviewError, match="读取原生渲染产物失败"):
+        core_preview.validate_core_output_readable(Path("preview.mp4"))
+
+
 async def test_preview_falls_back_when_native_rendering_fails(monkeypatch: pytest.MonkeyPatch):
     from nonebot_plugin_osubot.draw import osu_preview
 
@@ -56,3 +68,30 @@ async def test_preview_falls_back_when_native_rendering_fails(monkeypatch: pytes
     assert result == b"legacy-gif"
     native.assert_awaited_once_with(123, 0, 2, None, fmt="gif")
     legacy.assert_awaited_once_with(123, 456, full=False, target_mode=2)
+
+
+async def test_full_video_estimate_is_sent_once_when_native_falls_back(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    from nonebot_plugin_osubot.draw import osu_preview
+
+    native = AsyncMock(side_effect=osu_preview.CorePreviewError("broken"))
+    video = tmp_path / "preview.mp4"
+    video.write_bytes(b"video")
+
+    async def render_legacy(*_args: object, progress_callback, **_kwargs: object) -> Path:
+        await progress_callback(120.0)
+        return video
+
+    estimate = AsyncMock()
+    monkeypatch.setattr(osu_preview, "_core_full_video", native)
+    monkeypatch.setattr(osu_preview, "_legacy_draw_full_osu_preview", render_legacy)
+
+    result = await osu_preview.draw_full_osu_preview(
+        123,
+        456,
+        progress_callback=estimate,
+        source_mode=0,
+        target_mode=2,
+    )
+
+    assert result == video
+    estimate.assert_awaited_once_with(60.0)

--- a/tests/test_core_preview.py
+++ b/tests/test_core_preview.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+async def test_core_adapter_converts_only_standard_maps(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    from nonebot_plugin_osubot.draw import core_preview
+
+    output = tmp_path / "preview.gif"
+    output.write_bytes(b"GIF89a")
+    calls: list[dict[str, object]] = []
+
+    async def render(_beatmap_id: int | str, **kwargs: object) -> dict[str, str]:
+        calls.append(kwargs)
+        return {"preview-img": str(output)}
+
+    monkeypatch.setattr(core_preview, "generate_preview_async", render)
+
+    assert (
+        await core_preview.render_with_core(
+            123,
+            "gif",
+            source_mode=0,
+            target_mode=2,
+            mods=["HD", "GI", "F"],
+        )
+        == output
+    )
+    assert calls[-1]["convert"] == "ctb"
+    assert calls[-1]["mods"] == "hd"
+
+    await core_preview.render_with_core(123, "gif", source_mode=2, target_mode=2)
+    assert calls[-1]["convert"] is None
+
+
+async def test_core_adapter_rejects_missing_output(monkeypatch: pytest.MonkeyPatch):
+    from nonebot_plugin_osubot.draw import core_preview
+
+    monkeypatch.setattr(core_preview, "generate_preview_async", AsyncMock(return_value={}))
+
+    with pytest.raises(core_preview.CorePreviewError, match="preview-img"):
+        await core_preview.render_with_core(123, "png")
+
+
+async def test_preview_falls_back_when_native_rendering_fails(monkeypatch: pytest.MonkeyPatch):
+    from nonebot_plugin_osubot.draw import osu_preview
+
+    native = AsyncMock(side_effect=osu_preview.CorePreviewError("broken"))
+    legacy = AsyncMock(return_value=b"legacy-gif")
+    monkeypatch.setattr(osu_preview, "_core_bytes", native)
+    monkeypatch.setattr(osu_preview, "_legacy_draw_osu_preview", legacy)
+
+    result = await osu_preview.draw_osu_preview(123, 456, source_mode=0, target_mode=2)
+
+    assert result == b"legacy-gif"
+    native.assert_awaited_once_with(123, 0, 2, None, fmt="gif")
+    legacy.assert_awaited_once_with(123, 456, full=False, target_mode=2)

--- a/tests/test_matchers2.py
+++ b/tests/test_matchers2.py
@@ -698,7 +698,14 @@ async def test_preview_ctb_gif_param_uses_osu_preview_gif(app: App):
                     )
                     ctx.should_finished()
 
-                draw.assert_awaited_once_with(12345, 67890, False, target_mode=2)
+                draw.assert_awaited_once_with(
+                    12345,
+                    67890,
+                    False,
+                    target_mode=2,
+                    mods=["GI", "F"],
+                    source_mode=0,
+                )
 
 
 @pytest.mark.asyncio
@@ -716,8 +723,16 @@ async def test_full_preview_gif_param_sends_cached_video(app: App, tmp_path, com
     video.write_bytes(b"video")
     event = fake_group_message_event_v11(message=Message(command))
 
-    async def render_full_preview(beatmap_id, beatmapset_id, progress_callback, target_mode):
+    async def render_full_preview(
+        beatmap_id,
+        beatmapset_id,
+        progress_callback,
+        target_mode,
+        mods,
+        source_mode,
+    ):
         assert target_mode == 3
+        assert source_mode == 3
         await progress_callback(65)
         return video
 
@@ -762,8 +777,6 @@ async def test_full_preview_without_gif_keeps_mania_image(app: App, tmp_path):
 
     session = make_mock_session()
     session.scalar.return_value = make_mock_user(osu_id=114514, osu_mode=3)
-    osu_file = tmp_path / "map.osu"
-    osu_file.write_text("osu file format v14", encoding="utf-8")
     event = fake_group_message_event_v11(message=Message("/完整预览 12345"))
 
     with patch_session(UTILS_MODULE, session):
@@ -771,23 +784,30 @@ async def test_full_preview_without_gif_keeps_mania_image(app: App, tmp_path):
             f"{PREVIEW_MODULE}.osu_api",
             new=AsyncMock(return_value={"beatmapset_id": 67890, "mode_int": 3}),
         ):
-            with patch(f"{PREVIEW_MODULE}.download_osu", new=AsyncMock(return_value=osu_file)):
-                with patch(
-                    f"{PREVIEW_MODULE}.generate_preview_pic",
-                    new=AsyncMock(return_value=b"full-image"),
-                ) as draw:
-                    async with app.test_matcher(generate_preview) as ctx:
-                        adapter = nonebot.get_adapter(OnebotV11Adapter)
-                        bot = ctx.create_bot(base=Bot, adapter=adapter)
-                        ctx.receive_event(bot, event)
-                        ctx.should_call_send(
-                            event,
-                            img_msg(event, b"full-image"),
-                            result={"message_id": 1},
-                        )
-                        ctx.should_finished()
+            with patch(
+                f"{PREVIEW_MODULE}.render_preview",
+                new=AsyncMock(return_value=b"full-image"),
+            ) as draw:
+                async with app.test_matcher(generate_preview) as ctx:
+                    adapter = nonebot.get_adapter(OnebotV11Adapter)
+                    bot = ctx.create_bot(base=Bot, adapter=adapter)
+                    ctx.receive_event(bot, event)
+                    ctx.should_call_send(
+                        event,
+                        img_msg(event, b"full-image"),
+                        result={"message_id": 1},
+                    )
+                    ctx.should_finished()
 
-                    draw.assert_awaited_once_with(osu_file, True)
+                draw.assert_awaited_once_with(
+                    12345,
+                    67890,
+                    3,
+                    fmt="png",
+                    mods=[],
+                    source_mode=3,
+                    full_image=True,
+                )
 
 
 # ============================================================

--- a/uv.lock
+++ b/uv.lock
@@ -1530,7 +1530,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-osubot"
-version = "7.2.8"
+version = "7.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "expiringdict" },
@@ -1544,6 +1544,7 @@ dependencies = [
     { name = "nonebot-plugin-uninfo" },
     { name = "nonebot-plugin-waiter" },
     { name = "nonebot2" },
+    { name = "osu-beatmap-preview-py" },
     { name = "osu-tools-py" },
     { name = "pillow" },
     { name = "pydantic" },
@@ -1580,6 +1581,7 @@ requires-dist = [
     { name = "nonebot-plugin-uninfo", specifier = ">=0.11.1" },
     { name = "nonebot-plugin-waiter", specifier = ">=0.6.1" },
     { name = "nonebot2", specifier = ">=2.3.0" },
+    { name = "osu-beatmap-preview-py", specifier = ">=0.1.0,<0.2.0" },
     { name = "osu-tools-py", specifier = ">=0.1.4" },
     { name = "pillow", specifier = ">=9.2.0" },
     { name = "pydantic", specifier = ">=1.10.0,!=2.5.0,!=2.5.1,<3.0.0" },
@@ -1812,6 +1814,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/42/c2f93b6fee9b92ac80b8b75724b79422bf5a63d6cb81aeacb63349ca7d4b/osrparse-7.0.1.tar.gz", hash = "sha256:61e160979c1d1a796a25e83b55effc07ddfadcb126a5cec28b2244cb1b48acdd", size = 12001, upload-time = "2024-10-09T20:04:57.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/a4/aa42de117b3b7460b1f83b6ed0578d0a086245db6e90f6d0503d2057d76f/osrparse-7.0.1-py3-none-any.whl", hash = "sha256:84a0b3377d42751c3bea375b535dda0e71d90a8b378026f2f02b614553bb7163", size = 10486, upload-time = "2024-10-09T20:04:56.98Z" },
+]
+
+[[package]]
+name = "osu-beatmap-preview-py"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/c1/a89641eb6958e56d651998fcf75cf67292ce49753eb8951dbd4a4f9707ba/osu_beatmap_preview_py-0.1.0.tar.gz", hash = "sha256:587abe48d3bc7b2510431a706c21a2196addc2f043ef65248115bface0d3e318", size = 27832, upload-time = "2026-08-24T10:04:34.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/64/17335e74ef08d32c2d51c40ab87a8415de4cdfe7ae0cc35efa511e39bc75/osu_beatmap_preview_py-0.1.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bde6cdf02f96a1e5706f8fdbe9573a77532d05dd5883097bb73c5799214d0475", size = 2790250, upload-time = "2026-08-24T10:04:26.776Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ad/ad9dfadefd8c0626170125d2df68c63ed2598be2ed25530137acaa0a27cd/osu_beatmap_preview_py-0.1.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b17473e4ccc3a6a47fc7eae0d20d0e2fd0da556d3a8862bfed5231284da79459", size = 2652904, upload-time = "2026-08-24T10:04:28.344Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b7/9b5cfc95d302e193d7fa4333de93c2aaa94188ce7ecde0b879431820967c/osu_beatmap_preview_py-0.1.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:24f8e8db2cfa184d43bdea140333e4fb20418aca13b73ae5452a34e7b030ff2e", size = 2916148, upload-time = "2026-08-24T10:04:30.213Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/3cc218225723660fbf7fc8384e3df47630ea159a8ce8c68a2f0e521e4c99/osu_beatmap_preview_py-0.1.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3b793a97b6417b049e0d7e70305aba99c431bf457c98ca221bcb8ac7c0ce69f7", size = 3000531, upload-time = "2026-08-24T10:04:32.023Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/b5/1f6dcea8626431019ca864c5d3d918a3a941b12bd6bd1e303601faaadedc/osu_beatmap_preview_py-0.1.0-cp310-abi3-win_amd64.whl", hash = "sha256:d95bad8f7a0cae21354a3364a729a30fcd1c84d8e410595416cd7e887599107b", size = 2819647, upload-time = "2026-08-24T10:04:33.532Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

现有谱面预览依赖浏览器与 FFmpeg，完整视频渲染较慢。本 PR 改为通过 PyO3 在 Python 进程内调用 Rust 渲染器，同时保留旧链路作为自动回退。

## 主要改动

- 引入 `osu-beatmap-preview-py`，安装插件时自动安装对应平台的预编译 wheel
- 不再要求下载额外可执行文件，也不再新增二进制路径、开关或超时配置
- 支持 osu!、Taiko、Catch、Mania 的 PNG / GIF / MP4 原生渲染
- 仅在 Standard 谱面转换到其他模式时传递 convert，原生非 Standard 谱面直接按自身模式渲染
- 原生渲染失败、返回无效结果或读取产物失败时自动回退现有渲染链路
- 复用现有渲染并发配置，避免无上限并发调用 Rust 渲染器
- 保持原有命令语义：普通预览、`+GIF`、完整预览与完整视频按原行为输出
- 完整视频原生渲染开始前发送预计耗时提示

## 安装与兼容性

用户无需安装 Rust 或手动配置程序路径。支持的平台会直接安装 PyPI wheel；原生渲染不可用时插件仍会使用原有浏览器渲染链路。仅旧的完整视频回退链路需要 FFmpeg。

## 验证

- 完整测试：318 passed，37 skipped
- pre-commit：Ruff 与 Ruff format 均通过
- 新增原生模式转换、伪 Mod 清理、无效产物及自动回退测试
- Copilot review：修复跨平台 file URL、重复估时通知和过时 CLI 注释，并补充 MP4 读取失败回退

