### PR TITLE
fix(render): 支持远程 Playwright 加载本地模板资源

### DIFF
--- a/src/nonebot_plugin_osubot/draw/browser.py
+++ b/src/nonebot_plugin_osubot/draw/browser.py
@@ -1,9 +1,12 @@
 """HTMLRender 0.8 Playwright lease 上的持久页面池。"""
 
 import asyncio
+import os
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlsplit
 
 from nonebot import get_plugin_config
 from nonebot.log import logger
@@ -194,6 +197,43 @@ async def _drop_page(key: str) -> None:
     await entry.lease.__aexit__(None, None, None)
 
 
+def _file_uri_to_path(uri: str) -> Path:
+    """Convert an absolute file URI generated on this host back to a path."""
+    parsed = urlsplit(uri)
+    path = unquote(parsed.path)
+    if parsed.netloc and parsed.netloc != "localhost":
+        path = f"//{parsed.netloc}{path}"
+    elif os.name == "nt" and len(path) >= 3 and path[0] == "/" and path[2] == ":":
+        path = path[1:]
+    return Path(path)
+
+
+async def _install_remote_filehost_route(page: Any, app: Any) -> None:
+    """Proxy local file requests through htmlrender's configured filehost."""
+    strategy = app.resources.strategy
+    policy = getattr(strategy.remote_local_policy, "value", strategy.remote_local_policy)
+    if not strategy.is_remote or policy != "filehost":
+        return
+
+    async def handle_local_file(route: Any) -> None:
+        resolution = await app.resources.to_resource_url(
+            _file_uri_to_path(route.request.url),
+            strict=True,
+        )
+        headers = dict(resolution.request_headers_by_url.get(resolution.value, {}))
+        response = await page.context.request.get(
+            resolution.value,
+            headers=headers,
+            max_redirects=0,
+        )
+        try:
+            await route.fulfill(response=response)
+        finally:
+            await response.dispose()
+
+    await page.route("file://**", handle_local_file)
+
+
 async def _create_page(
     key: str,
     goto_uri: str | None,
@@ -213,6 +253,7 @@ async def _create_page(
         # 原始 ProviderLifecycleError 为 "generator didn't stop after athrow()"。
         raise
     try:
+        await _install_remote_filehost_route(page, app)
         if goto_uri:
             # 持久页导航主要用于建立 file:// 基准地址。等待完整 load 会被
             # 模板中的远程头像、封面等资源拖住；具体渲染函数会自行等待

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -7,16 +7,27 @@ import pytest
 class FakePage:
     def __init__(self):
         self.closed = False
+        self.fail_file_navigation = False
         self.goto_calls = []
         self.reload_calls = []
         self.viewport_calls = []
         self.evaluate_calls = []
+        self.route_calls = []
+        self.context = SimpleNamespace(request=FakeAPIRequest())
 
     def is_closed(self):
         return self.closed
 
     async def goto(self, uri, *, wait_until):
         self.goto_calls.append((uri, wait_until))
+        if self.fail_file_navigation and uri.startswith("file://"):
+            if not self.route_calls:
+                raise RuntimeError("NS_ERROR_FILE_NOT_FOUND")
+            _, handler = self.route_calls[-1]
+            await handler(FakeRoute(uri))
+
+    async def route(self, pattern, handler):
+        self.route_calls.append((pattern, handler))
 
     async def set_viewport_size(self, viewport):
         self.viewport_calls.append(viewport)
@@ -49,13 +60,60 @@ class FakePlaywright:
         self.leases = []
         self.options = []
         self.next_enter_error = None
+        self.next_page_file_navigation_fails = False
 
     def page(self, **options):
         lease = FakeLease(self.next_enter_error)
         self.next_enter_error = None
+        lease.page.fail_file_navigation = self.next_page_file_navigation_fails
+        self.next_page_file_navigation_fails = False
         self.leases.append(lease)
         self.options.append(options)
         return lease
+
+
+class FakeRoute:
+    def __init__(self, url):
+        self.request = SimpleNamespace(url=url)
+        self.fulfilled = None
+
+    async def fulfill(self, **kwargs):
+        self.fulfilled = kwargs
+
+
+class FakeAPIResponse:
+    def __init__(self):
+        self.disposed = False
+
+    async def dispose(self):
+        self.disposed = True
+
+
+class FakeAPIRequest:
+    def __init__(self):
+        self.calls = []
+
+    async def get(self, url, **kwargs):
+        response = FakeAPIResponse()
+        self.calls.append((url, kwargs, response))
+        return response
+
+
+class FakeResources:
+    def __init__(self):
+        self.strategy = SimpleNamespace(
+            is_remote=True,
+            remote_local_policy="filehost",
+        )
+        self.resolve_calls = []
+
+    async def to_resource_url(self, path, **kwargs):
+        self.resolve_calls.append((path, kwargs))
+        url = "http://osubot:8080/_htmlrender/assets/recommend.html"
+        return SimpleNamespace(
+            value=url,
+            request_headers_by_url={url: {"X-HTMLRender-Filehost-Request": "guard"}},
+        )
 
 
 @pytest.fixture
@@ -63,7 +121,15 @@ def browser_pool(monkeypatch):
     from nonebot_plugin_osubot.draw import browser
 
     playwright = FakePlaywright()
-    app = SimpleNamespace(extensions=SimpleNamespace(playwright=playwright))
+    app = SimpleNamespace(
+        extensions=SimpleNamespace(playwright=playwright),
+        resources=SimpleNamespace(
+            strategy=SimpleNamespace(
+                is_remote=False,
+                remote_local_policy="memory",
+            )
+        ),
+    )
     monkeypatch.setattr(browser, "get_default_application", lambda: app)
     browser._pages.clear()
     browser._locks.clear()
@@ -97,6 +163,35 @@ async def test_persistent_page_reuses_lease_and_updates_viewport(browser_pool):
 
     await browser.close_persistent_pages()
     assert playwright.leases[0].exit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_persistent_page_routes_local_templates_for_remote_filehost(browser_pool, tmp_path):
+    browser, playwright = browser_pool
+    app = browser.get_default_application()
+    app.resources = FakeResources()
+    playwright.next_page_file_navigation_fails = True
+    template = tmp_path / "recommend.html"
+    template.write_text("<html></html>", encoding="utf-8")
+
+    async with browser.persistent_page(
+        "recommend",
+        template.as_uri(),
+        {"width": 1080, "height": 600},
+    ):
+        pass
+
+    page = playwright.leases[0].page
+    assert page.route_calls
+    assert app.resources.resolve_calls[0][0] == template
+    assert app.resources.resolve_calls[0][1] == {"strict": True}
+    url, options, response = page.context.request.calls[0]
+    assert url == "http://osubot:8080/_htmlrender/assets/recommend.html"
+    assert options == {
+        "headers": {"X-HTMLRender-Filehost-Request": "guard"},
+        "max_redirects": 0,
+    }
+    assert response.disposed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

osubot 的持久页面池直接使用 htmlrender 暴露的 raw Playwright page。远端 Playwright 与 Bot 文件系统隔离时，`page.goto(file://...)` 会在远端容器查找模板并报 `NS_ERROR_FILE_NOT_FOUND`。

## 修复

- 仅在 htmlrender 判定当前 Provider 为远端且本地资源策略为 `filehost` 时安装 `file://` 请求路由
- 保留原始 `file://` 文档地址，使模板中的相对 CSS、JS 和图片仍按原目录解析
- 每个本地资源通过 htmlrender 的公开资源服务解析为 filehost URL
- 使用该资源对应的精确授权头从远端 Playwright 请求，再回填原始页面请求
- 请求禁止自动重定向，响应完成后主动释放
- 本地 Playwright 和其他资源策略保持原行为

## 测试

- 新增远端 filehost 回归测试，复现并消除 `NS_ERROR_FILE_NOT_FOUND`
- 浏览器页面池测试：9 passed
- 完整测试：345 passed, 37 skipped
- Ruff / Ruff format / pre-commit：通过

Closes #152